### PR TITLE
environment composer refactor

### DIFF
--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -119,6 +119,9 @@ export const VersionSelect = ({
         }
       }}
     >
+      <MenuItem key="empty" value="" sx={{ height: "30px" }}>
+        {" "}
+      </MenuItem>
       {versionsList.map(v => (
         <MenuItem key={v} value={v}>
           {v}

--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -83,7 +83,7 @@ export const VersionSelect = ({
 
   return (
     <Select
-      value={value}
+      value={versionsList.length > 0 ? value : ""}
       open={open}
       onClose={() => setOpen(false)}
       onOpen={() => setOpen(true)}

--- a/src/features/channels/components/ChannelsEdit.tsx
+++ b/src/features/channels/components/ChannelsEdit.tsx
@@ -23,7 +23,7 @@ import { reorderArray } from "../../../utils/helpers";
 export interface IChannelsEditProps {
   /**
    * @param channelsList list of channels
-   * @param updateChannels notify the parent if there are changes in channelsList array.
+   * @param updateChannels handler that will update the channels list
    */
   channelsList: string[];
   updateChannels: (channels: string[]) => void;
@@ -36,29 +36,24 @@ export const ChannelsEdit = ({
   const { palette } = useTheme();
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  // const [list, setList] = useState(channelsList);
   const [isAdding, setIsAdding] = useState(false);
 
   const listLength = channelsList.length;
 
   const addNewChannel = (channelName: string) => {
-    // setList([...list, channelName]);
     updateChannels([...channelsList, channelName]);
   };
 
   const removeChannel = (channelName: string) => {
-    // const filteredList = (currentData: string[]) =>
-    //   currentData.filter(item => item !== channelName);
-
-    // setList(filteredList);
     updateChannels(channelsList.filter(item => item !== channelName));
   };
 
   const editChannel = (channelName: string, newChannelName: string) => {
-    // const newChannelsList = channelsList.map(channel =>
-    //   channel === channelName ? newChannelName : channel
-    // );
-    // setList(newChannelsList);
+    const newChannelsList = channelsList.map(channel =>
+      channel === channelName ? newChannelName : channel
+    );
+
+    updateChannels(newChannelsList);
   };
 
   const onDragEnd = (result: DropResult) => {
@@ -73,7 +68,6 @@ export const ChannelsEdit = ({
       endIndex: destination.index
     });
 
-    // setList(reorderedArray);
     updateChannels(reorderedArray);
   };
 

--- a/src/features/channels/components/ChannelsEdit.tsx
+++ b/src/features/channels/components/ChannelsEdit.tsx
@@ -36,30 +36,29 @@ export const ChannelsEdit = ({
   const { palette } = useTheme();
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  const [list, setList] = useState(channelsList);
+  // const [list, setList] = useState(channelsList);
   const [isAdding, setIsAdding] = useState(false);
 
-  const listLength = list.length;
+  const listLength = channelsList.length;
 
   const addNewChannel = (channelName: string) => {
-    setList([...list, channelName]);
-    updateChannels([...list, channelName]);
+    // setList([...list, channelName]);
+    updateChannels([...channelsList, channelName]);
   };
 
   const removeChannel = (channelName: string) => {
-    const filteredList = (currentData: string[]) =>
-      currentData.filter(item => item !== channelName);
+    // const filteredList = (currentData: string[]) =>
+    //   currentData.filter(item => item !== channelName);
 
-    setList(filteredList);
-    updateChannels(list.filter(item => item !== channelName));
+    // setList(filteredList);
+    updateChannels(channelsList.filter(item => item !== channelName));
   };
 
   const editChannel = (channelName: string, newChannelName: string) => {
-    const newChannelsList = list.map(channel =>
-      channel === channelName ? newChannelName : channel
-    );
-
-    setList(newChannelsList);
+    // const newChannelsList = channelsList.map(channel =>
+    //   channel === channelName ? newChannelName : channel
+    // );
+    // setList(newChannelsList);
   };
 
   const onDragEnd = (result: DropResult) => {
@@ -69,12 +68,12 @@ export const ChannelsEdit = ({
 
     const { destination, source } = result;
     const reorderedArray = reorderArray({
-      list,
+      list: channelsList,
       startIndex: source.index,
       endIndex: destination.index
     });
 
-    setList(reorderedArray);
+    // setList(reorderedArray);
     updateChannels(reorderedArray);
   };
 
@@ -105,7 +104,7 @@ export const ChannelsEdit = ({
                 borderRadius: "0px"
               }}
             >
-              {list.map((channel, index) => (
+              {channelsList.map((channel, index) => (
                 <Draggable key={channel} draggableId={channel} index={index}>
                   {provided => (
                     <Box

--- a/src/features/channels/components/ChannelsEdit.tsx
+++ b/src/features/channels/components/ChannelsEdit.tsx
@@ -1,8 +1,8 @@
+import React, { useState, useRef, useEffect, memo } from "react";
 import { useTheme } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import Box from "@mui/material/Box";
-import React, { useState, useRef, useEffect } from "react";
 import {
   DragDropContext,
   Draggable,
@@ -29,7 +29,7 @@ export interface IChannelsEditProps {
   updateChannels: (channels: string[]) => void;
 }
 
-export const ChannelsEdit = ({
+const BaseChannelsEdit = ({
   channelsList,
   updateChannels
 }: IChannelsEditProps) => {
@@ -150,3 +150,18 @@ export const ChannelsEdit = ({
     </Accordion>
   );
 };
+
+// rerender only when the passed channelsList and update handler are different then the previous props
+const compareProps = (
+  prevProps: IChannelsEditProps,
+  nextProps: IChannelsEditProps
+) => {
+  const isSameArray =
+    JSON.stringify(prevProps.channelsList) ===
+    JSON.stringify(nextProps.channelsList);
+  const isSameFunc = prevProps.updateChannels === nextProps.updateChannels;
+
+  return isSameArray && isSameFunc;
+};
+
+export const ChannelsEdit = memo(BaseChannelsEdit, compareProps);

--- a/src/features/channels/components/ChannelsEdit.tsx
+++ b/src/features/channels/components/ChannelsEdit.tsx
@@ -33,12 +33,12 @@ const BaseChannelsEdit = ({
   channelsList,
   updateChannels
 }: IChannelsEditProps) => {
+  const listLength = channelsList.length;
   const { palette } = useTheme();
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const expandedRef = useRef(listLength > 0);
 
   const [isAdding, setIsAdding] = useState(false);
-
-  const listLength = channelsList.length;
 
   const addNewChannel = (channelName: string) => {
     updateChannels([...channelsList, channelName]);
@@ -79,7 +79,7 @@ const BaseChannelsEdit = ({
 
   return (
     <Accordion
-      defaultExpanded={listLength > 0}
+      defaultExpanded={expandedRef.current}
       sx={{ width: 421, boxShadow: "none" }}
       disableGutters
     >

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -1,4 +1,3 @@
-import React, { useRef, useState } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -8,7 +7,10 @@ import {
   TableRow,
   Typography
 } from "@mui/material";
+import useTheme from "@mui/material/styles/useTheme";
 import { Box } from "@mui/system";
+import React, { useRef, useState } from "react";
+import { useAppDispatch, useAppSelector } from "../../../hooks";
 import {
   StyledAccordionDetails,
   StyledAccordionExpandIcon,
@@ -18,13 +20,7 @@ import {
   StyledEditPackagesTableCell
 } from "../../../styles";
 import { AddRequestedPackage } from "../../requestedPackages";
-import useTheme from "@mui/material/styles/useTheme";
-import {
-  requestedPackageRemoved,
-  requestedPackagesChanged,
-  requestedPackageUpdated
-} from "../environmentCreateSlice";
-import { useAppDispatch, useAppSelector } from "../../../hooks";
+import { requestedPackagesChanged } from "../environmentCreateSlice";
 import { CreateEnvironmentPackagesTableRow } from "./CreateEnvironmentPackagesTableRow";
 
 export const CreateEnvironmentPackages = () => {
@@ -35,17 +31,6 @@ export const CreateEnvironmentPackages = () => {
   const [isAdding, setIsAdding] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { palette } = useTheme();
-
-  const handleRemovePackage = (requestedPackage: string) => {
-    dispatch(requestedPackageRemoved(requestedPackage));
-  };
-
-  const handleUpdatePackage = (
-    currentPackage: string,
-    updatedPackage: string
-  ) => {
-    dispatch(requestedPackageUpdated({ currentPackage, updatedPackage }));
-  };
 
   return (
     <Accordion
@@ -91,10 +76,8 @@ export const CreateEnvironmentPackages = () => {
           <TableBody>
             {requestedPackages.map(requestedPackage => (
               <CreateEnvironmentPackagesTableRow
-                handleUpdate={handleUpdatePackage}
                 key={requestedPackage}
                 requestedPackage={requestedPackage}
-                onRemove={handleRemovePackage}
               />
             ))}
           </TableBody>

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -10,7 +10,7 @@ import {
 import useTheme from "@mui/material/styles/useTheme";
 import { Box } from "@mui/system";
 import React, { useRef, useState } from "react";
-import { useAppDispatch, useAppSelector } from "../../../hooks";
+import { useAppDispatch } from "../../../hooks";
 import {
   StyledAccordionDetails,
   StyledAccordionExpandIcon,
@@ -23,11 +23,14 @@ import { AddRequestedPackage } from "../../requestedPackages";
 import { requestedPackagesChanged } from "../environmentCreateSlice";
 import { CreateEnvironmentPackagesTableRow } from "./CreateEnvironmentPackagesTableRow";
 
-export const CreateEnvironmentPackages = () => {
+interface ICreateEnvironmentPackagesProps {
+  requestedPackages: string[];
+}
+
+export const CreateEnvironmentPackages = ({
+  requestedPackages
+}: ICreateEnvironmentPackagesProps) => {
   const dispatch = useAppDispatch();
-  const { requestedPackages } = useAppSelector(
-    state => state.environmentCreate
-  );
   const [isAdding, setIsAdding] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { palette } = useTheme();

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -21,7 +21,8 @@ import { AddRequestedPackage } from "../../requestedPackages";
 import useTheme from "@mui/material/styles/useTheme";
 import {
   requestedPackageRemoved,
-  requestedPackagesChanged
+  requestedPackagesChanged,
+  requestedPackageUpdated
 } from "../environmentCreateSlice";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
 import { CreateEnvironmentPackagesTableRow } from "./CreateEnvironmentPackagesTableRow";
@@ -37,6 +38,13 @@ export const CreateEnvironmentPackages = () => {
 
   const handleRemovePackage = (requestedPackage: string) => {
     dispatch(requestedPackageRemoved(requestedPackage));
+  };
+
+  const handleUpdatePackage = (
+    currentPackage: string,
+    updatedPackage: string
+  ) => {
+    dispatch(requestedPackageUpdated({ currentPackage, updatedPackage }));
   };
 
   return (
@@ -83,6 +91,7 @@ export const CreateEnvironmentPackages = () => {
           <TableBody>
             {requestedPackages.map(requestedPackage => (
               <CreateEnvironmentPackagesTableRow
+                handleUpdate={handleUpdatePackage}
                 key={requestedPackage}
                 requestedPackage={requestedPackage}
                 onRemove={handleRemovePackage}

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -19,8 +19,14 @@ import {
 } from "../../../styles";
 import { AddRequestedPackage } from "../../requestedPackages";
 import useTheme from "@mui/material/styles/useTheme";
+import { requestedPackagesChanged } from "../environmentCreateSlice";
+import { useAppDispatch, useAppSelector } from "../../../hooks";
 
 export const CreateEnvironmentPackages = () => {
+  const dispatch = useAppDispatch();
+  const { requestedPackages } = useAppSelector(
+    state => state.environmentCreate
+  );
   const [isAdding, setIsAdding] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { palette } = useTheme();
@@ -56,21 +62,6 @@ export const CreateEnvironmentPackages = () => {
                   Name
                 </Typography>
               </StyledEditPackagesTableCell>
-              {/* {!isCreating && (
-                <StyledEditPackagesTableCell
-                  align="left"
-                  sx={{
-                    width: "180px"
-                  }}
-                >
-                  <Typography
-                    component="p"
-                    sx={{ fontSize: "16px", fontWeight: 500 }}
-                  >
-                    Installed Version
-                  </Typography>
-                </StyledEditPackagesTableCell>
-              )} */}
               <StyledEditPackagesTableCell align="left">
                 <Typography
                   component="p"
@@ -96,8 +87,12 @@ export const CreateEnvironmentPackages = () => {
         <Box ref={scrollRef}>
           {isAdding && (
             <AddRequestedPackage
-              onSubmit={() => {}}
-              onCancel={() => {}}
+              onSubmit={(value: string) =>
+                dispatch(
+                  requestedPackagesChanged([...requestedPackages, value])
+                )
+              }
+              onCancel={() => setIsAdding(false)}
               isCreating={true}
             />
           )}

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -24,6 +24,9 @@ import { requestedPackagesChanged } from "../environmentCreateSlice";
 import { CreateEnvironmentPackagesTableRow } from "./CreateEnvironmentPackagesTableRow";
 
 interface ICreateEnvironmentPackagesProps {
+  /**
+   * @param requestedPackages list of created packages
+   */
   requestedPackages: string[];
 }
 

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import useTheme from "@mui/material/styles/useTheme";
 import { Box } from "@mui/system";
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useAppDispatch } from "../../../hooks";
 import {
   StyledAccordionDetails,
@@ -37,6 +37,12 @@ export const CreateEnvironmentPackages = ({
   const [isAdding, setIsAdding] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { palette } = useTheme();
+
+  useEffect(() => {
+    if (isAdding && scrollRef.current) {
+      scrollRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [isAdding]);
 
   return (
     <Accordion

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -19,8 +19,12 @@ import {
 } from "../../../styles";
 import { AddRequestedPackage } from "../../requestedPackages";
 import useTheme from "@mui/material/styles/useTheme";
-import { requestedPackagesChanged } from "../environmentCreateSlice";
+import {
+  requestedPackageRemoved,
+  requestedPackagesChanged
+} from "../environmentCreateSlice";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
+import { CreateEnvironmentPackagesTableRow } from "./CreateEnvironmentPackagesTableRow";
 
 export const CreateEnvironmentPackages = () => {
   const dispatch = useAppDispatch();
@@ -30,6 +34,10 @@ export const CreateEnvironmentPackages = () => {
   const [isAdding, setIsAdding] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { palette } = useTheme();
+
+  const handleRemovePackage = (requestedPackage: string) => {
+    dispatch(requestedPackageRemoved(requestedPackage));
+  };
 
   return (
     <Accordion
@@ -73,15 +81,13 @@ export const CreateEnvironmentPackages = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {/* {filteredPackageList.map(requestedPackage => (
-              <RequestedPackagesTableRow
-                onUpdate={updatePackage}
-                onRemove={removePackage}
-                key={`${requestedPackage}`}
-                requestedPackage={`${requestedPackage}`}
-                isCreating={isCreating}
+            {requestedPackages.map(requestedPackage => (
+              <CreateEnvironmentPackagesTableRow
+                key={requestedPackage}
+                requestedPackage={requestedPackage}
+                onRemove={handleRemovePackage}
               />
-            ))} */}
+            ))}
           </TableBody>
         </Table>
         <Box ref={scrollRef}>

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -1,0 +1,125 @@
+import React, { useRef, useState } from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  Table,
+  TableBody,
+  TableHead,
+  TableRow,
+  Typography
+} from "@mui/material";
+import { Box } from "@mui/system";
+import {
+  StyledAccordionDetails,
+  StyledAccordionExpandIcon,
+  StyledAccordionSummary,
+  StyledAccordionTitle,
+  StyledButtonPrimary,
+  StyledEditPackagesTableCell
+} from "../../../styles";
+import { AddRequestedPackage } from "../../requestedPackages";
+import useTheme from "@mui/material/styles/useTheme";
+
+export const CreateEnvironmentPackages = () => {
+  const [isAdding, setIsAdding] = useState(false);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const { palette } = useTheme();
+
+  return (
+    <Accordion
+      sx={{ width: 421, boxShadow: "none" }}
+      defaultExpanded
+      disableGutters
+    >
+      <StyledAccordionSummary expandIcon={<StyledAccordionExpandIcon />}>
+        <StyledAccordionTitle>Requested Packages</StyledAccordionTitle>
+      </StyledAccordionSummary>
+      <StyledAccordionDetails
+        sx={{
+          padding: "23px 21px",
+          borderRadius: "0px"
+        }}
+      >
+        <Table aria-label="requested packages">
+          <TableHead sx={{ border: "none" }}>
+            <TableRow>
+              <StyledEditPackagesTableCell
+                align="left"
+                sx={{
+                  width: "120px"
+                }}
+              >
+                <Typography
+                  component="p"
+                  sx={{ fontSize: "16px", fontWeight: 500 }}
+                >
+                  Name
+                </Typography>
+              </StyledEditPackagesTableCell>
+              {/* {!isCreating && (
+                <StyledEditPackagesTableCell
+                  align="left"
+                  sx={{
+                    width: "180px"
+                  }}
+                >
+                  <Typography
+                    component="p"
+                    sx={{ fontSize: "16px", fontWeight: 500 }}
+                  >
+                    Installed Version
+                  </Typography>
+                </StyledEditPackagesTableCell>
+              )} */}
+              <StyledEditPackagesTableCell align="left">
+                <Typography
+                  component="p"
+                  sx={{ fontSize: "16px", fontWeight: 500 }}
+                >
+                  Version Constraint
+                </Typography>
+              </StyledEditPackagesTableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {/* {filteredPackageList.map(requestedPackage => (
+              <RequestedPackagesTableRow
+                onUpdate={updatePackage}
+                onRemove={removePackage}
+                key={`${requestedPackage}`}
+                requestedPackage={`${requestedPackage}`}
+                isCreating={isCreating}
+              />
+            ))} */}
+          </TableBody>
+        </Table>
+        <Box ref={scrollRef}>
+          {isAdding && (
+            <AddRequestedPackage
+              onSubmit={() => {}}
+              onCancel={() => {}}
+              isCreating={true}
+            />
+          )}
+        </Box>
+      </StyledAccordionDetails>
+      <AccordionDetails
+        sx={{
+          border: `1px solid ${palette.primary.main}`,
+          borderTop: "0px",
+          borderRadius: "0px 0px 5px 5px",
+          padding: "15px 21px",
+          display: "flex",
+          justifyContent: "center"
+        }}
+      >
+        <StyledButtonPrimary
+          variant="contained"
+          onClick={() => setIsAdding(true)}
+        >
+          + Add Package
+        </StyledButtonPrimary>
+      </AccordionDetails>
+    </Accordion>
+  );
+};

--- a/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
@@ -1,0 +1,55 @@
+import { Box, TableRow, Typography } from "@mui/material";
+import React from "react";
+import { ConstraintSelect, VersionSelect } from "../../../components";
+import DeleteIcon from "@mui/icons-material/Delete";
+import {
+  StyledIconButton,
+  StyledRequestedPackagesTableCell
+} from "../../../styles";
+import { requestedPackageParser } from "../../../utils/helpers";
+
+interface IProps {
+  /**
+   * @param requestedPackage requested package
+   * @param onRemove handler that will run when delete icon is clicked
+   */
+  requestedPackage: string;
+  onRemove: (packageName: string) => void;
+}
+
+export const CreateEnvironmentPackagesTableRow = ({
+  requestedPackage,
+  onRemove
+}: IProps) => {
+  const { version, constraint, name } =
+    requestedPackageParser(requestedPackage);
+
+  return (
+    <TableRow>
+      <StyledRequestedPackagesTableCell align="left">
+        <Typography sx={{ fontSize: "16px", fontWeight: 400, color: "#000" }}>
+          {name}
+        </Typography>
+      </StyledRequestedPackagesTableCell>
+      <StyledRequestedPackagesTableCell align="left">
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <ConstraintSelect
+            onUpdate={() => {}}
+            constraint={constraint === "latest" ? "" : constraint}
+          />
+          <VersionSelect
+            onUpdate={() => {}}
+            version={constraint === "latest" ? "" : version}
+            name={name}
+          />
+          <StyledIconButton
+            onClick={() => onRemove(requestedPackage)}
+            sx={{ marginLeft: "24px" }}
+          >
+            <DeleteIcon />
+          </StyledIconButton>
+        </Box>
+      </StyledRequestedPackagesTableCell>
+    </TableRow>
+  );
+};

--- a/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
@@ -12,17 +12,34 @@ interface IProps {
   /**
    * @param requestedPackage requested package
    * @param onRemove handler that will run when delete icon is clicked
+   * @param handleUpdate handler that will run when a package is updated
    */
   requestedPackage: string;
   onRemove: (packageName: string) => void;
+  handleUpdate: (currentPackage: string, updatedPackage: string) => void;
 }
 
 export const CreateEnvironmentPackagesTableRow = ({
   requestedPackage,
-  onRemove
+  onRemove,
+  handleUpdate
 }: IProps) => {
   const { version, constraint, name } =
     requestedPackageParser(requestedPackage);
+
+  const handleUpdateConstraint = (value: string) => {
+    const updatedPackage = `${name}${value}${version}`;
+
+    handleUpdate(requestedPackage, updatedPackage);
+  };
+
+  const handleUpdateVersion = (value: string) => {
+    const updatedPackage = `${name}${
+      constraint === "latest" ? ">=" : constraint
+    }${value}`;
+
+    handleUpdate(requestedPackage, updatedPackage);
+  };
 
   return (
     <TableRow>
@@ -34,11 +51,11 @@ export const CreateEnvironmentPackagesTableRow = ({
       <StyledRequestedPackagesTableCell align="left">
         <Box sx={{ display: "flex", alignItems: "center" }}>
           <ConstraintSelect
-            onUpdate={() => {}}
+            onUpdate={handleUpdateConstraint}
             constraint={constraint === "latest" ? "" : constraint}
           />
           <VersionSelect
-            onUpdate={() => {}}
+            onUpdate={handleUpdateVersion}
             version={constraint === "latest" ? "" : version}
             name={name}
           />

--- a/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
@@ -1,5 +1,5 @@
-import { Box, TableRow, Typography } from "@mui/material";
 import React from "react";
+import { Box, TableRow, Typography } from "@mui/material";
 import { ConstraintSelect, VersionSelect } from "../../../components";
 import DeleteIcon from "@mui/icons-material/Delete";
 import {
@@ -7,30 +7,35 @@ import {
   StyledRequestedPackagesTableCell
 } from "../../../styles";
 import { requestedPackageParser } from "../../../utils/helpers";
+import { useAppDispatch } from "../../../hooks";
+import {
+  requestedPackageRemoved,
+  requestedPackageUpdated
+} from "../environmentCreateSlice";
 
 interface IProps {
   /**
    * @param requestedPackage requested package
-   * @param onRemove handler that will run when delete icon is clicked
-   * @param handleUpdate handler that will run when a package is updated
    */
   requestedPackage: string;
-  onRemove: (packageName: string) => void;
-  handleUpdate: (currentPackage: string, updatedPackage: string) => void;
 }
 
 export const CreateEnvironmentPackagesTableRow = ({
-  requestedPackage,
-  onRemove,
-  handleUpdate
+  requestedPackage
 }: IProps) => {
+  const dispatch = useAppDispatch();
   const { version, constraint, name } =
     requestedPackageParser(requestedPackage);
 
   const handleUpdateConstraint = (value: string) => {
     const updatedPackage = `${name}${value}${version}`;
 
-    handleUpdate(requestedPackage, updatedPackage);
+    dispatch(
+      requestedPackageUpdated({
+        currentPackage: requestedPackage,
+        updatedPackage
+      })
+    );
   };
 
   const handleUpdateVersion = (value: string) => {
@@ -38,7 +43,16 @@ export const CreateEnvironmentPackagesTableRow = ({
       constraint === "latest" ? ">=" : constraint
     }${value}`;
 
-    handleUpdate(requestedPackage, updatedPackage);
+    dispatch(
+      requestedPackageUpdated({
+        currentPackage: requestedPackage,
+        updatedPackage
+      })
+    );
+  };
+
+  const handleRemovePackage = (requestedPackage: string) => {
+    dispatch(requestedPackageRemoved(requestedPackage));
   };
 
   return (
@@ -60,7 +74,7 @@ export const CreateEnvironmentPackagesTableRow = ({
             name={name}
           />
           <StyledIconButton
-            onClick={() => onRemove(requestedPackage)}
+            onClick={() => handleRemovePackage(requestedPackage)}
             sx={{ marginLeft: "24px" }}
           >
             <DeleteIcon />

--- a/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { Box, TableRow, Typography } from "@mui/material";
 import { ConstraintSelect, VersionSelect } from "../../../components";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -20,7 +20,7 @@ interface IProps {
   requestedPackage: string;
 }
 
-export const CreateEnvironmentPackagesTableRow = ({
+const BaseCreateEnvironmentPackagesTableRow = ({
   requestedPackage
 }: IProps) => {
   const dispatch = useAppDispatch();
@@ -84,3 +84,7 @@ export const CreateEnvironmentPackagesTableRow = ({
     </TableRow>
   );
 };
+
+export const CreateEnvironmentPackagesTableRow = memo(
+  BaseCreateEnvironmentPackagesTableRow
+);

--- a/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackagesTableRow.tsx
@@ -39,9 +39,13 @@ const BaseCreateEnvironmentPackagesTableRow = ({
   };
 
   const handleUpdateVersion = (value: string) => {
-    const updatedPackage = `${name}${
-      constraint === "latest" ? ">=" : constraint
-    }${value}`;
+    let pkgConstraint = constraint === "latest" ? ">=" : constraint;
+
+    if (value === "") {
+      pkgConstraint = "";
+    }
+
+    const updatedPackage = `${name}${pkgConstraint}${value}`;
 
     dispatch(
       requestedPackageUpdated({

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -16,6 +16,8 @@ import {
 } from "../../../features/tabs";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
 import { SpecificationCreate, SpecificationReadOnly } from "./Specification";
+import { debounce } from "lodash";
+import { descriptionChanged, nameChanged } from "../environmentCreateSlice";
 
 export interface IEnvCreate {
   environmentNotification: (notification: any) => void;
@@ -23,14 +25,25 @@ export interface IEnvCreate {
 export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
   const dispatch = useAppDispatch();
   const { mode } = useAppSelector(state => state.environmentDetails);
+  const { name, description } = useAppSelector(
+    state => state.environmentCreate
+  );
   const { newEnvironment } = useAppSelector(state => state.tabs);
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
+  // const [name, setName] = useState("");
+  // const [description, setDescription] = useState("");
   const [error, setError] = useState({
     message: "",
     visible: false
   });
   const [createOrUpdate] = useCreateOrUpdateMutation();
+
+  const handleChangeName = debounce((value: string) => {
+    dispatch(nameChanged(value));
+  }, 300);
+
+  const handleChangeDescription = debounce((value: string) => {
+    dispatch(descriptionChanged(value));
+  }, 300);
 
   const createEnvironment = async (code: any) => {
     const namespace = newEnvironment?.namespace;
@@ -77,7 +90,7 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
 
   return (
     <Box sx={{ padding: "14px 12px" }}>
-      <EnvironmentDetailsHeader envName={name} onUpdateName={setName} />
+      <EnvironmentDetailsHeader onUpdateName={handleChangeName} />
       {error.visible && (
         <Alert
           severity="error"
@@ -91,10 +104,9 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
       <Box sx={{ marginBottom: "30px" }}>
         <EnvMetadata
           selectedEnv={{}}
-          description={description}
           current_build_id={0}
           mode={mode}
-          onUpdateDescription={setDescription}
+          onUpdateDescription={handleChangeDescription}
         />
       </Box>
       <Box sx={{ marginBottom: "30px" }}>

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -22,15 +22,18 @@ import { descriptionChanged, nameChanged } from "../environmentCreateSlice";
 export interface IEnvCreate {
   environmentNotification: (notification: any) => void;
 }
+
+interface ICreateEnvironmentArgs {
+  code: { channels: string[]; dependencies: string[] } | null;
+}
+
 export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
   const dispatch = useAppDispatch();
   const { mode } = useAppSelector(state => state.environmentDetails);
-  const { name, description } = useAppSelector(
+  const { name, description, channels, requestedPackages } = useAppSelector(
     state => state.environmentCreate
   );
   const { newEnvironment } = useAppSelector(state => state.tabs);
-  // const [name, setName] = useState("");
-  // const [description, setDescription] = useState("");
   const [error, setError] = useState({
     message: "",
     visible: false
@@ -45,12 +48,14 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
     dispatch(descriptionChanged(value));
   }, 300);
 
-  const createEnvironment = async (code: any) => {
+  const createEnvironment = async (code: ICreateEnvironmentArgs) => {
+    const envCode = code ? code : { channels, dependencies: requestedPackages };
+
     const namespace = newEnvironment?.namespace;
     const environmentInfo = {
       namespace,
       specification: `${stringify(
-        code
+        envCode
       )}\ndescription: ${description}\nname: ${name}\nprefix: null`
     };
 

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -16,7 +16,11 @@ import {
 import { useAppDispatch, useAppSelector } from "../../../hooks";
 import { SpecificationCreate, SpecificationReadOnly } from "./Specification";
 import { debounce } from "lodash";
-import { descriptionChanged, nameChanged } from "../environmentCreateSlice";
+import {
+  descriptionChanged,
+  environmentCreated,
+  nameChanged
+} from "../environmentCreateSlice";
 
 export interface IEnvCreate {
   environmentNotification: (notification: any) => void;
@@ -82,6 +86,7 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
         show: true,
         description: `${name} environment is being created`
       });
+      dispatch(environmentCreated());
     } catch ({ data }) {
       setError({
         message: data.message,

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -16,11 +16,7 @@ import {
 import { useAppDispatch, useAppSelector } from "../../../hooks";
 import { SpecificationCreate, SpecificationReadOnly } from "./Specification";
 import { debounce } from "lodash";
-import {
-  descriptionChanged,
-  environmentCreated,
-  nameChanged
-} from "../environmentCreateSlice";
+import { descriptionChanged, nameChanged } from "../environmentCreateSlice";
 
 export interface IEnvCreate {
   environmentNotification: (notification: any) => void;
@@ -86,7 +82,6 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
         show: true,
         description: `${name} environment is being created`
       });
-      dispatch(environmentCreated());
     } catch ({ data }) {
       setError({
         message: data.message,

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import Alert from "@mui/material/Alert";
 import { stringify } from "yaml";
-
 import {
   EnvironmentDetailsHeader,
   modeChanged,
@@ -24,13 +23,13 @@ export interface IEnvCreate {
 }
 
 interface ICreateEnvironmentArgs {
-  code: { channels: string[]; dependencies: string[] } | null;
+  code: { channels: string[]; dependencies: string[] };
 }
 
 export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
   const dispatch = useAppDispatch();
   const { mode } = useAppSelector(state => state.environmentDetails);
-  const { name, description, channels, requestedPackages } = useAppSelector(
+  const { name, description } = useAppSelector(
     state => state.environmentCreate
   );
   const { newEnvironment } = useAppSelector(state => state.tabs);
@@ -49,13 +48,11 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
   }, 300);
 
   const createEnvironment = async (code: ICreateEnvironmentArgs) => {
-    const envCode = code ? code : { channels, dependencies: requestedPackages };
-
     const namespace = newEnvironment?.namespace;
     const environmentInfo = {
       namespace,
       specification: `${stringify(
-        envCode
+        code
       )}\ndescription: ${description}\nname: ${name}\nprefix: null`
     };
 

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import Box from "@mui/material/Box";
 import { ChannelsEdit } from "../../../../features/channels";
 import { BlockContainerEditMode } from "../../../../components";
@@ -24,9 +24,12 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     dependencies: string[];
   }>({ channels: [], dependencies: [] });
 
-  const onUpdateChannels = (channels: string[]) => {
-    dispatch(channelsChanged(channels));
-  };
+  const onUpdateChannels = useCallback(
+    (channels: string[]) => {
+      dispatch(channelsChanged(channels));
+    },
+    [channels]
+  );
 
   const onUpdateEditor = debounce(
     ({

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -6,20 +6,24 @@ import { StyledButtonPrimary } from "../../../../styles";
 import { CodeEditor } from "../../../../features/yamlEditor";
 import { stringify } from "yaml";
 import { CreateEnvironmentPackages } from "../CreateEnvironmentPackages";
+import { useAppDispatch, useAppSelector } from "../../../../hooks";
+import { channelsChanged } from "../../environmentCreateSlice";
 
 export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
+  const dispatch = useAppDispatch();
+  const { channels } = useAppSelector(state => state.environmentCreate);
   const [show, setShow] = useState(false);
-  const [channels, setChannels] = useState<string[]>([]);
-  const [requestedPackages, setPackages] = useState<string[]>([]);
-  const [newChannels, setNewChannels] = useState(channels);
-  const [newPackages, setNewPackages] = useState(requestedPackages);
+  // const [channels, setChannels] = useState<string[]>([]);
+  // const [requestedPackages, setPackages] = useState<string[]>([]);
+  // const [newChannels, setNewChannels] = useState(channels);
+  // const [newPackages, setNewPackages] = useState(requestedPackages);
   const [code, setCode] = useState({
     channels,
-    dependencies: requestedPackages
+    dependencies: []
   });
 
   const onUpdateChannels = (channels: string[]) => {
-    setChannels(channels);
+    dispatch(channelsChanged(channels));
   };
 
   // const onUpdatePackages = (packages: string[]) => {
@@ -27,38 +31,38 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
   // };
 
   const onUpdateEditor = ({ channels, dependencies }: any) => {
-    setNewChannels(channels);
-    setNewPackages(dependencies);
+    // setNewChannels(channels);
+    // setNewPackages(dependencies);
   };
 
   const onToggleEditorView = (value: boolean) => {
     setShow(value);
-    if (!value) {
-      // If user want to switch the yaml editor view, let's send this info to the component
-      setChannels(newChannels);
-      setPackages(newPackages);
-    }
+    // if (!value) {
+    //   // If user want to switch the yaml editor view, let's send this info to the component
+    //   setChannels(newChannels);
+    //   setPackages(newPackages);
+    // }
   };
 
   const onUpdateEnvironment = () => {
-    if (show) {
-      setChannels(newChannels);
-      setPackages(newPackages);
-    }
-    onCreateEnvironment({
-      channels: newChannels,
-      dependencies: newPackages
-    });
+    // if (show) {
+    //   setChannels(newChannels);
+    //   setPackages(newPackages);
+    // }
+    // onCreateEnvironment({
+    //   channels: channels,
+    //   dependencies: newPackages
+    // });
   };
 
   useEffect(() => {
     setCode({
       channels,
-      dependencies: requestedPackages
+      dependencies: []
     });
-    setNewChannels(channels);
-    setNewPackages(requestedPackages);
-  }, [channels, requestedPackages]);
+    // setNewChannels(channels);
+    // setNewPackages(requestedPackages);
+  }, [channels]);
 
   return (
     <BlockContainerEditMode

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import { ChannelsEdit } from "../../../../features/channels";
 import { BlockContainerEditMode } from "../../../../components";
@@ -7,41 +7,38 @@ import { CodeEditor } from "../../../../features/yamlEditor";
 import { stringify } from "yaml";
 import { CreateEnvironmentPackages } from "../CreateEnvironmentPackages";
 import { useAppDispatch, useAppSelector } from "../../../../hooks";
-import { channelsChanged } from "../../environmentCreateSlice";
+import {
+  channelsChanged,
+  editorCodeUpdated
+} from "../../environmentCreateSlice";
+import { debounce } from "lodash";
 
 export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
   const dispatch = useAppDispatch();
-  const { channels } = useAppSelector(state => state.environmentCreate);
+  const { channels, requestedPackages } = useAppSelector(
+    state => state.environmentCreate
+  );
   const [show, setShow] = useState(false);
-  // const [channels, setChannels] = useState<string[]>([]);
-  // const [requestedPackages, setPackages] = useState<string[]>([]);
-  // const [newChannels, setNewChannels] = useState(channels);
-  // const [newPackages, setNewPackages] = useState(requestedPackages);
-  const [code, setCode] = useState({
-    channels,
-    dependencies: []
-  });
 
   const onUpdateChannels = (channels: string[]) => {
     dispatch(channelsChanged(channels));
   };
 
-  // const onUpdatePackages = (packages: string[]) => {
-  //   setPackages(packages);
-  // };
-
-  const onUpdateEditor = ({ channels, dependencies }: any) => {
-    // setNewChannels(channels);
-    // setNewPackages(dependencies);
-  };
+  const onUpdateEditor = debounce(
+    ({
+      channels,
+      dependencies
+    }: {
+      channels: string[];
+      dependencies: string[];
+    }) => {
+      dispatch(editorCodeUpdated({ channels, dependencies }));
+    },
+    300
+  );
 
   const onToggleEditorView = (value: boolean) => {
     setShow(value);
-    // if (!value) {
-    //   // If user want to switch the yaml editor view, let's send this info to the component
-    //   setChannels(newChannels);
-    //   setPackages(newPackages);
-    // }
   };
 
   const onUpdateEnvironment = () => {
@@ -55,15 +52,6 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     // });
   };
 
-  useEffect(() => {
-    setCode({
-      channels,
-      dependencies: []
-    });
-    // setNewChannels(channels);
-    // setNewPackages(requestedPackages);
-  }, [channels]);
-
   return (
     <BlockContainerEditMode
       title="Specification"
@@ -72,15 +60,16 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     >
       <Box sx={{ padding: "13px 19px" }}>
         {show ? (
-          <CodeEditor code={stringify(code)} onChangeEditor={onUpdateEditor} />
+          <CodeEditor
+            code={stringify({
+              channels,
+              dependencies: requestedPackages
+            })}
+            onChangeEditor={onUpdateEditor}
+          />
         ) : (
           <>
             <Box sx={{ marginBottom: "30px" }}>
-              {/* <RequestedPackagesEdit
-                packageList={requestedPackages}
-                updatePackages={onUpdatePackages}
-                isCreating={true}
-              /> */}
               <CreateEnvironmentPackages />
             </Box>
             <Box sx={{ margiBottom: "30px" }}>

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -24,12 +24,9 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     dependencies: string[];
   }>({ channels: [], dependencies: [] });
 
-  const onUpdateChannels = useCallback(
-    (channels: string[]) => {
-      dispatch(channelsChanged(channels));
-    },
-    [channels]
-  );
+  const onUpdateChannels = useCallback((channels: string[]) => {
+    dispatch(channelsChanged(channels));
+  }, []);
 
   const onUpdateEditor = debounce(
     ({
@@ -93,7 +90,9 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
         ) : (
           <>
             <Box sx={{ marginBottom: "30px" }}>
-              <CreateEnvironmentPackages />
+              <CreateEnvironmentPackages
+                requestedPackages={requestedPackages}
+              />
             </Box>
             <Box sx={{ margiBottom: "30px" }}>
               <ChannelsEdit

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import { ChannelsEdit } from "../../../../features/channels";
 import { BlockContainerEditMode } from "../../../../components";
@@ -9,7 +9,8 @@ import { CreateEnvironmentPackages } from "../CreateEnvironmentPackages";
 import { useAppDispatch, useAppSelector } from "../../../../hooks";
 import {
   channelsChanged,
-  editorCodeUpdated
+  editorCodeUpdated,
+  environmentCreateStateCleared
 } from "../../environmentCreateSlice";
 
 export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
@@ -69,6 +70,12 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
 
     onCreateEnvironment(code);
   };
+
+  useEffect(() => {
+    return () => {
+      dispatch(environmentCreateStateCleared());
+    };
+  }, []);
 
   return (
     <BlockContainerEditMode

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -67,7 +67,9 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
   };
 
   const handleSubmit = () => {
-    const code = show ? editorContent : null;
+    const code = show
+      ? editorContent
+      : { dependencies: requestedPackages, channels };
 
     onCreateEnvironment(code);
   };

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -80,8 +80,8 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
         {show ? (
           <CodeEditor
             code={stringify({
-              dependencies: requestedPackages,
-              channels
+              channels,
+              dependencies: requestedPackages
             })}
             onChangeEditor={onUpdateEditor}
           />

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -19,6 +19,10 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     state => state.environmentCreate
   );
   const [show, setShow] = useState(false);
+  const [editorContent, setEditorContent] = useState<{
+    channels: string[];
+    dependencies: string[];
+  }>({ channels: [], dependencies: [] });
 
   const onUpdateChannels = (channels: string[]) => {
     dispatch(channelsChanged(channels));
@@ -32,24 +36,38 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
       channels: string[];
       dependencies: string[];
     }) => {
-      dispatch(editorCodeUpdated({ channels, dependencies }));
+      const code = { channels, dependencies };
+
+      if (!channels || channels.length === 0) {
+        code.channels = [];
+      }
+
+      if (!dependencies || dependencies.length === 0) {
+        code.dependencies = [];
+      }
+
+      setEditorContent(code);
     },
     300
   );
 
   const onToggleEditorView = (value: boolean) => {
+    if (show) {
+      dispatch(
+        editorCodeUpdated({
+          channels: editorContent.channels,
+          dependencies: editorContent.dependencies
+        })
+      );
+    }
+
     setShow(value);
   };
 
-  const onUpdateEnvironment = () => {
-    // if (show) {
-    //   setChannels(newChannels);
-    //   setPackages(newPackages);
-    // }
-    // onCreateEnvironment({
-    //   channels: channels,
-    //   dependencies: newPackages
-    // });
+  const handleSubmit = () => {
+    const code = show ? editorContent : null;
+
+    onCreateEnvironment(code);
   };
 
   return (
@@ -62,8 +80,8 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
         {show ? (
           <CodeEditor
             code={stringify({
-              channels,
-              dependencies: requestedPackages
+              dependencies: requestedPackages,
+              channels
             })}
             onChangeEditor={onUpdateEditor}
           />
@@ -90,7 +108,7 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
         >
           <StyledButtonPrimary
             sx={{ padding: "5px 60px" }}
-            onClick={onUpdateEnvironment}
+            onClick={handleSubmit}
           >
             Create
           </StyledButtonPrimary>

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -11,7 +11,6 @@ import {
   channelsChanged,
   editorCodeUpdated
 } from "../../environmentCreateSlice";
-import { debounce } from "lodash";
 
 export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
   const dispatch = useAppDispatch();
@@ -28,28 +27,25 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     dispatch(channelsChanged(channels));
   }, []);
 
-  const onUpdateEditor = debounce(
-    ({
-      channels,
-      dependencies
-    }: {
-      channels: string[];
-      dependencies: string[];
-    }) => {
-      const code = { channels, dependencies };
+  const onUpdateEditor = ({
+    channels,
+    dependencies
+  }: {
+    channels: string[];
+    dependencies: string[];
+  }) => {
+    const code = { channels, dependencies };
 
-      if (!channels || channels.length === 0) {
-        code.channels = [];
-      }
+    if (!channels || channels.length === 0) {
+      code.channels = [];
+    }
 
-      if (!dependencies || dependencies.length === 0) {
-        code.dependencies = [];
-      }
+    if (!dependencies || dependencies.length === 0) {
+      code.dependencies = [];
+    }
 
-      setEditorContent(code);
-    },
-    300
-  );
+    setEditorContent(code);
+  };
 
   const onToggleEditorView = (value: boolean) => {
     if (show) {

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from "react";
 import Box from "@mui/material/Box";
 import { ChannelsEdit } from "../../../../features/channels";
-import { RequestedPackagesEdit } from "../../../../features/requestedPackages";
 import { BlockContainerEditMode } from "../../../../components";
 import { StyledButtonPrimary } from "../../../../styles";
 import { CodeEditor } from "../../../../features/yamlEditor";
 import { stringify } from "yaml";
+import { CreateEnvironmentPackages } from "../CreateEnvironmentPackages";
 
 export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
   const [show, setShow] = useState(false);
@@ -22,9 +22,9 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
     setChannels(channels);
   };
 
-  const onUpdatePackages = (packages: string[]) => {
-    setPackages(packages);
-  };
+  // const onUpdatePackages = (packages: string[]) => {
+  //   setPackages(packages);
+  // };
 
   const onUpdateEditor = ({ channels, dependencies }: any) => {
     setNewChannels(channels);
@@ -72,11 +72,12 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
         ) : (
           <>
             <Box sx={{ marginBottom: "30px" }}>
-              <RequestedPackagesEdit
+              {/* <RequestedPackagesEdit
                 packageList={requestedPackages}
                 updatePackages={onUpdatePackages}
                 isCreating={true}
-              />
+              /> */}
+              <CreateEnvironmentPackages />
             </Box>
             <Box sx={{ margiBottom: "30px" }}>
               <ChannelsEdit

--- a/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
+++ b/src/features/environmentCreate/components/Specification/SpecificationCreate.tsx
@@ -59,6 +59,8 @@ export const SpecificationCreate = ({ onCreateEnvironment }: any) => {
           dependencies: editorContent.dependencies
         })
       );
+    } else {
+      setEditorContent({ dependencies: requestedPackages, channels });
     }
 
     setShow(value);

--- a/src/features/environmentCreate/components/index.ts
+++ b/src/features/environmentCreate/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./EnvironmentCreate";
 export * from "./Specification";
+export * from "./CreateEnvironmentPackages";

--- a/src/features/environmentCreate/components/index.ts
+++ b/src/features/environmentCreate/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./EnvironmentCreate";
 export * from "./Specification";
 export * from "./CreateEnvironmentPackages";
+export * from "./CreateEnvironmentPackagesTableRow";

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -29,6 +29,11 @@ export const environmentCreateSlice = createSlice({
     },
     requestedPackagesChanged: (state, action: PayloadAction<string[]>) => {
       state.requestedPackages = action.payload;
+    },
+    requestedPackageRemoved: (state, action: PayloadAction<string>) => {
+      state.requestedPackages = state.requestedPackages.filter(
+        p => p !== action.payload
+      );
     }
   }
 });
@@ -37,5 +42,6 @@ export const {
   nameChanged,
   descriptionChanged,
   channelsChanged,
-  requestedPackagesChanged
+  requestedPackagesChanged,
+  requestedPackageRemoved
 } = environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -44,6 +44,13 @@ export const environmentCreateSlice = createSlice({
       state.requestedPackages = state.requestedPackages.map(p =>
         p === currentPackage ? updatedPackage : p
       );
+    },
+    editorCodeUpdated: (
+      state,
+      action: PayloadAction<{ dependencies: string[]; channels: string[] }>
+    ) => {
+      state.requestedPackages = action.payload.dependencies;
+      state.channels = action.payload.channels;
     }
   }
 });
@@ -54,5 +61,6 @@ export const {
   channelsChanged,
   requestedPackagesChanged,
   requestedPackageRemoved,
-  requestedPackageUpdated
+  requestedPackageUpdated,
+  editorCodeUpdated
 } = environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -23,9 +23,12 @@ export const environmentCreateSlice = createSlice({
     },
     descriptionChanged: (state, action: PayloadAction<string>) => {
       state.description = action.payload;
+    },
+    channelsChanged: (state, action: PayloadAction<string[]>) => {
+      state.channels = action.payload;
     }
   }
 });
 
-export const { nameChanged, descriptionChanged } =
+export const { nameChanged, descriptionChanged, channelsChanged } =
   environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -26,9 +26,16 @@ export const environmentCreateSlice = createSlice({
     },
     channelsChanged: (state, action: PayloadAction<string[]>) => {
       state.channels = action.payload;
+    },
+    requestedPackagesChanged: (state, action: PayloadAction<string[]>) => {
+      state.requestedPackages = action.payload;
     }
   }
 });
 
-export const { nameChanged, descriptionChanged, channelsChanged } =
-  environmentCreateSlice.actions;
+export const {
+  nameChanged,
+  descriptionChanged,
+  channelsChanged,
+  requestedPackagesChanged
+} = environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -51,6 +51,12 @@ export const environmentCreateSlice = createSlice({
     ) => {
       state.requestedPackages = action.payload.dependencies;
       state.channels = action.payload.channels;
+    },
+    environmentCreated: state => {
+      state.name = "";
+      state.description = "";
+      state.channels = [];
+      state.requestedPackages = [];
     }
   }
 });
@@ -62,5 +68,6 @@ export const {
   requestedPackagesChanged,
   requestedPackageRemoved,
   requestedPackageUpdated,
-  editorCodeUpdated
+  editorCodeUpdated,
+  environmentCreated
 } = environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export interface IEnvironmentCreateState {
+  name: string;
+  description: string;
+  requestedPackages: string[];
+  channels: string[];
+}
+
+const initialState: IEnvironmentCreateState = {
+  name: "",
+  description: "",
+  channels: [],
+  requestedPackages: []
+};
+
+export const environmentCreateSlice = createSlice({
+  name: "environmentCreate",
+  initialState,
+  reducers: {
+    nameChanged: (state, action: PayloadAction<string>) => {
+      state.name = action.payload;
+    },
+    descriptionChanged: (state, action: PayloadAction<string>) => {
+      state.description = action.payload;
+    }
+  }
+});
+
+export const { nameChanged, descriptionChanged } =
+  environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -52,7 +52,7 @@ export const environmentCreateSlice = createSlice({
       state.requestedPackages = action.payload.dependencies;
       state.channels = action.payload.channels;
     },
-    environmentCreated: state => {
+    environmentCreateStateCleared: state => {
       state.name = "";
       state.description = "";
       state.channels = [];
@@ -69,5 +69,5 @@ export const {
   requestedPackageRemoved,
   requestedPackageUpdated,
   editorCodeUpdated,
-  environmentCreated
+  environmentCreateStateCleared
 } = environmentCreateSlice.actions;

--- a/src/features/environmentCreate/environmentCreateSlice.ts
+++ b/src/features/environmentCreate/environmentCreateSlice.ts
@@ -34,6 +34,16 @@ export const environmentCreateSlice = createSlice({
       state.requestedPackages = state.requestedPackages.filter(
         p => p !== action.payload
       );
+    },
+    requestedPackageUpdated: (
+      state,
+      action: PayloadAction<{ currentPackage: string; updatedPackage: string }>
+    ) => {
+      const { currentPackage, updatedPackage } = action.payload;
+
+      state.requestedPackages = state.requestedPackages.map(p =>
+        p === currentPackage ? updatedPackage : p
+      );
     }
   }
 });
@@ -43,5 +53,6 @@ export const {
   descriptionChanged,
   channelsChanged,
   requestedPackagesChanged,
-  requestedPackageRemoved
+  requestedPackageRemoved,
+  requestedPackageUpdated
 } = environmentCreateSlice.actions;

--- a/src/features/environmentCreate/index.ts
+++ b/src/features/environmentCreate/index.ts
@@ -1,1 +1,2 @@
 export * from "./components";
+export * from "./environmentCreateSlice";

--- a/src/features/environmentDetails/components/EnvironmentDetails.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetails.tsx
@@ -1,6 +1,6 @@
+import React, { useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import Alert from "@mui/material/Alert";
-import React, { useEffect, useState } from "react";
 import { stringify } from "yaml";
 
 import { EnvironmentDetailsHeader } from "./EnvironmentDetailsHeader";
@@ -19,9 +19,17 @@ import {
 } from "../../../features/environmentDetails";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
 import artifactList from "../../../utils/helpers/artifact";
+import { CondaSpecificationPip } from "../../../common/models";
 
 export interface IEnvDetails {
   environmentNotification: (notification: any) => void;
+}
+
+interface IUpdateEnvironmentArgs {
+  code: {
+    dependencies: (string | CondaSpecificationPip)[];
+    channels: string[];
+  };
 }
 
 export const EnvironmentDetails = ({
@@ -50,7 +58,7 @@ export const EnvironmentDetails = ({
     });
   }
 
-  const updateEnvironment = async (code: any) => {
+  const updateEnvironment = async (code: IUpdateEnvironmentArgs) => {
     const namespace = selectedEnvironment?.namespace.name;
 
     const environmentInfo = {

--- a/src/features/environmentDetails/components/EnvironmentDetails.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetails.tsx
@@ -19,6 +19,8 @@ import {
 import { useAppDispatch, useAppSelector } from "../../../hooks";
 import artifactList from "../../../utils/helpers/artifact";
 import { CondaSpecificationPip } from "../../../common/models";
+import { updatePackages } from "../../requestedPackages";
+import { updateChannels } from "../../channels";
 
 interface IEnvDetails {
   environmentNotification: (notification: any) => void;
@@ -84,6 +86,8 @@ export const EnvironmentDetails = ({
       });
       await createOrUpdate(environmentInfo).unwrap();
       dispatch(modeChanged(EnvironmentDetailsModes.READ));
+      dispatch(updatePackages(code.code.dependencies));
+      dispatch(updateChannels(code.code.channels));
       environmentNotification({
         show: true,
         description: `${name} environment has been updated`

--- a/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
@@ -14,12 +14,12 @@ interface IEnvironmentDetailsHeaderProps {
    * @param envName name of the selected environment
    * @param onUpdateName change environment name
    */
-  envName: string;
+  envName?: string;
   onUpdateName: (value: string) => void;
 }
 
 export const EnvironmentDetailsHeader = ({
-  envName,
+  envName = "",
   onUpdateName
 }: IEnvironmentDetailsHeaderProps) => {
   const { mode } = useAppSelector(state => state.environmentDetails);
@@ -68,7 +68,6 @@ export const EnvironmentDetailsHeader = ({
               }
             }}
             variant="filled"
-            value={envName}
             placeholder="Environment name"
             onChange={e => onUpdateName(e.target.value)}
           />

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -35,6 +35,9 @@ export const SpecificationEdit = ({
   const { dependencies, size, count, page } = useAppSelector(
     state => state.dependencies
   );
+  const { updatedConstraints } = useAppSelector(
+    state => state.environmentDetails
+  );
   const hasMore = size * page <= count;
   const dispatch = useAppDispatch();
   const [show, setShow] = useState(false);
@@ -92,7 +95,23 @@ export const SpecificationEdit = ({
       dispatch(updatePackages(code.dependencies));
       dispatch(updateChannels(code.channels));
     } else {
-      setCode({ dependencies: requestedPackages, channels });
+      const updatedPackageList = requestedPackages.map(p => {
+        if (typeof p === "object") {
+          return p;
+        }
+
+        const { name } = requestedPackageParser(p as string);
+        const updatedConstraint = updatedConstraints[name];
+
+        if (updatedConstraint) {
+          return `${name}${updatedConstraint.range}${updatedConstraint.version}`;
+        }
+
+        return p;
+      });
+
+      dispatch(updatePackages(updatedPackageList));
+      setCode({ dependencies: updatedPackageList, channels });
     }
 
     setShow(value);

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import Box from "@mui/material/Box";
-import { cloneDeep, debounce } from "lodash";
+import { cloneDeep } from "lodash";
 import { stringify } from "yaml";
 import { BlockContainerEditMode } from "../../../../components";
 import { ChannelsEdit, updateChannels } from "../../../../features/channels";
@@ -42,28 +42,25 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
     dispatch(updateChannels(channels));
   }, []);
 
-  const onUpdateEditor = debounce(
-    ({
-      channels,
-      dependencies
-    }: {
-      channels: string[];
-      dependencies: string[];
-    }) => {
-      const code = { dependencies, channels };
+  const onUpdateEditor = ({
+    channels,
+    dependencies
+  }: {
+    channels: string[];
+    dependencies: string[];
+  }) => {
+    const code = { dependencies, channels };
 
-      if (!channels || channels.length === 0) {
-        code.channels = [];
-      }
+    if (!channels || channels.length === 0) {
+      code.channels = [];
+    }
 
-      if (!dependencies || dependencies.length === 0) {
-        code.dependencies = [];
-      }
+    if (!dependencies || dependencies.length === 0) {
+      code.dependencies = [];
+    }
 
-      setCode(code);
-    },
-    300
-  );
+    setCode(code);
+  };
 
   const onToggleEditorView = (value: boolean) => {
     if (show) {

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -57,6 +57,7 @@ export const SpecificationEdit = ({
   const stringifiedInitialChannels = useMemo(() => {
     return JSON.stringify(initialChannels.current);
   }, [initialChannels.current]);
+
   const stringifiedInitialPackages = useMemo(() => {
     return JSON.stringify(initialPackages.current);
   }, [initialPackages.current]);

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -30,24 +30,12 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
   const dispatch = useAppDispatch();
   const [show, setShow] = useState(false);
   const [code, setCode] = useState({});
-  // const [newChannels, setNewChannels] = useState(channels);
   const initialChannels = useRef(cloneDeep(channels));
-  // const [newPackages, setNewPackages] = useState(requestedPackages);
   const initialPackages = useRef(cloneDeep(requestedPackages));
-
-  // const onUpdatePackages = (packages: string[]) => {
-  //   dispatch(updatePackages(packages));
-  //   setNewPackages(packages);
-  // };
 
   const onUpdateChannels = (channels: string[]) => {
     dispatch(updateChannels(channels));
   };
-
-  // const onUpdateEditor = ({ channels, dependencies }: any) => {
-  //   setNewChannels(channels);
-  //   setNewPackages(dependencies);
-  // };
 
   const onToggleEditorView = (value: boolean) => {
     setShow(value);
@@ -89,10 +77,6 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
     }
   }, [channels, requestedPackages]);
 
-  // useEffect(() => {
-  //   setNewPackages(requestedPackages);
-  // }, [requestedPackages]);
-
   return (
     <BlockContainerEditMode
       title="Specification"
@@ -105,10 +89,7 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
         ) : (
           <>
             <Box sx={{ marginBottom: "30px" }}>
-              <RequestedPackagesEdit
-                packageList={requestedPackages}
-                updatePackages={() => {}}
-              />
+              <RequestedPackagesEdit packageList={requestedPackages} />
             </Box>
             <Box sx={{ marginBottom: "30px" }}>
               <Dependencies

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -109,7 +109,6 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
               <RequestedPackagesEdit
                 packageList={requestedPackages}
                 updatePackages={onUpdatePackages}
-                isCreating={false}
               />
             </Box>
             <Box sx={{ marginBottom: "30px" }}>

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import Box from "@mui/material/Box";
 import { cloneDeep, debounce } from "lodash";
 import { stringify } from "yaml";
-
 import { BlockContainerEditMode } from "../../../../components";
 import { ChannelsEdit, updateChannels } from "../../../../features/channels";
 import { Dependencies, pageChanged } from "../../../../features/dependencies";
@@ -39,9 +38,9 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
   const initialChannels = useRef(cloneDeep(channels));
   const initialPackages = useRef(cloneDeep(requestedPackages));
 
-  const onUpdateChannels = (channels: string[]) => {
+  const onUpdateChannels = useCallback((channels: string[]) => {
     dispatch(updateChannels(channels));
-  };
+  }, []);
 
   const onUpdateEditor = debounce(
     ({

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -120,7 +120,7 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
       <Box sx={{ padding: "13px 19px" }}>
         {show ? (
           <CodeEditor
-            code={stringify({ dependencies: requestedPackages, channels })}
+            code={stringify({ channels, dependencies: requestedPackages })}
             onChangeEditor={onUpdateEditor}
           />
         ) : (

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -17,14 +17,8 @@ import { CodeEditor } from "../../../../features/yamlEditor";
 import { useAppDispatch, useAppSelector } from "../../../../hooks";
 import { StyledButtonPrimary } from "../../../../styles";
 import { CondaSpecificationPip } from "../../../../common/models";
-import {
-  requestedPackageParser,
-  updatePackagesWithConstraints
-} from "../../../../utils/helpers";
-import {
-  constraintsCleared,
-  installedVersionsGenerated
-} from "../../environmentDetailsSlice";
+import { requestedPackageParser } from "../../../../utils/helpers";
+import { installedVersionsGenerated } from "../../environmentDetailsSlice";
 
 interface ISpecificationEdit {
   descriptionUpdated: boolean;
@@ -40,9 +34,6 @@ export const SpecificationEdit = ({
   );
   const { dependencies, size, count, page } = useAppSelector(
     state => state.dependencies
-  );
-  const { updatedConstraints } = useAppSelector(
-    state => state.environmentDetails
   );
   const hasMore = size * page <= count;
   const dispatch = useAppDispatch();
@@ -100,34 +91,17 @@ export const SpecificationEdit = ({
     if (show) {
       dispatch(updatePackages(code.dependencies));
       dispatch(updateChannels(code.channels));
-      dispatch(constraintsCleared());
     } else {
-      const updatedPackageList = updatePackagesWithConstraints(
-        updatedConstraints,
-        requestedPackages
-      );
-
-      dispatch(updatePackages(updatedPackageList));
-      setCode({ dependencies: updatedPackageList, channels });
+      setCode({ dependencies: requestedPackages, channels });
     }
 
     setShow(value);
   };
 
   const onEditEnvironment = () => {
-    let updatedPackageList: (string | CondaSpecificationPip)[] = [];
-
-    if (!show) {
-      updatedPackageList = updatePackagesWithConstraints(
-        updatedConstraints,
-        requestedPackages
-      );
-      dispatch(updatePackages(updatedPackageList));
-    }
-
     const envContent = show
       ? code
-      : { dependencies: updatedPackageList, channels };
+      : { dependencies: requestedPackages, channels };
 
     onUpdateEnvironment(envContent);
   };
@@ -159,7 +133,6 @@ export const SpecificationEdit = ({
     dispatch(installedVersionsGenerated(versions));
 
     return () => {
-      dispatch(constraintsCleared());
       dispatch(installedVersionsGenerated({}));
     };
   }, []);
@@ -179,11 +152,7 @@ export const SpecificationEdit = ({
     if (JSON.stringify(requestedPackages) !== stringifiedInitialPackages) {
       setEnvIsUpdated(true);
     }
-
-    if (Object.keys(updatedConstraints).length > 0) {
-      setEnvIsUpdated(true);
-    }
-  }, [channels, requestedPackages, descriptionUpdated, updatedConstraints]);
+  }, [channels, requestedPackages, descriptionUpdated]);
 
   return (
     <BlockContainerEditMode

--- a/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
+++ b/src/features/environmentDetails/components/Specification/SpecificationEdit.tsx
@@ -1,5 +1,5 @@
+import React, { useState, useEffect, useRef } from "react";
 import Box from "@mui/material/Box";
-import React, { useState, useEffect } from "react";
 import { cloneDeep } from "lodash";
 import { stringify } from "yaml";
 
@@ -30,51 +30,50 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
   const dispatch = useAppDispatch();
   const [show, setShow] = useState(false);
   const [code, setCode] = useState({});
-  const [newChannels, setNewChannels] = useState(channels);
-  const [backupChannels] = useState(cloneDeep(channels));
-  const [newPackages, setNewPackages] = useState(requestedPackages);
-  const [backupPackages] = useState(cloneDeep(requestedPackages));
+  // const [newChannels, setNewChannels] = useState(channels);
+  const initialChannels = useRef(cloneDeep(channels));
+  // const [newPackages, setNewPackages] = useState(requestedPackages);
+  const initialPackages = useRef(cloneDeep(requestedPackages));
 
-  const onUpdatePackages = (packages: string[]) => {
-    dispatch(updatePackages(packages));
-    setNewPackages(packages);
-  };
+  // const onUpdatePackages = (packages: string[]) => {
+  //   dispatch(updatePackages(packages));
+  //   setNewPackages(packages);
+  // };
 
   const onUpdateChannels = (channels: string[]) => {
-    setNewChannels(channels);
+    dispatch(updateChannels(channels));
   };
 
-  const onUpdateEditor = ({ channels, dependencies }: any) => {
-    setNewChannels(channels);
-    setNewPackages(dependencies);
-  };
+  // const onUpdateEditor = ({ channels, dependencies }: any) => {
+  //   setNewChannels(channels);
+  //   setNewPackages(dependencies);
+  // };
 
   const onToggleEditorView = (value: boolean) => {
     setShow(value);
-    if (!value) {
-      // If user want to switch the yaml editor view, let's send this info to the component
-      dispatch(updatePackages(newPackages));
-    }
-    dispatch(updateChannels(newChannels));
+    // if (!value) {
+    //   // If user want to switch the yaml editor view, let's send this info to the component
+    //   dispatch(updatePackages(newPackages));
+    // }
+    // dispatch(updateChannels(newChannels));
   };
 
   const onEditEnvironment = () => {
-    if (show) {
-      // If user is using the yaml editor, before make the request update the store
-      dispatch(updateChannels(newChannels));
-      dispatch(updatePackages(newPackages));
-    }
-
-    onUpdateEnvironment({
-      channels: newChannels,
-      dependencies: newPackages
-    });
+    // if (show) {
+    //   // If user is using the yaml editor, before make the request update the store
+    //   dispatch(updateChannels(newChannels));
+    //   dispatch(updatePackages(newPackages));
+    // }
+    // onUpdateEnvironment({
+    //   channels: newChannels,
+    //   dependencies: newPackages
+    // });
   };
 
   const onCancelEdition = () => {
     dispatch(modeChanged(EnvironmentDetailsModes.READ));
-    dispatch(updatePackages(backupPackages));
-    dispatch(updateChannels(backupChannels));
+    dispatch(updatePackages(initialPackages.current));
+    dispatch(updateChannels(initialChannels.current));
   };
 
   useEffect(() => {
@@ -90,9 +89,9 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
     }
   }, [channels, requestedPackages]);
 
-  useEffect(() => {
-    setNewPackages(requestedPackages);
-  }, [requestedPackages]);
+  // useEffect(() => {
+  //   setNewPackages(requestedPackages);
+  // }, [requestedPackages]);
 
   return (
     <BlockContainerEditMode
@@ -102,13 +101,13 @@ export const SpecificationEdit = ({ onUpdateEnvironment }: any) => {
     >
       <Box sx={{ padding: "13px 19px" }}>
         {show ? (
-          <CodeEditor code={stringify(code)} onChangeEditor={onUpdateEditor} />
+          <CodeEditor code={stringify(code)} onChangeEditor={() => {}} />
         ) : (
           <>
             <Box sx={{ marginBottom: "30px" }}>
               <RequestedPackagesEdit
                 packageList={requestedPackages}
-                updatePackages={onUpdatePackages}
+                updatePackages={() => {}}
               />
             </Box>
             <Box sx={{ marginBottom: "30px" }}>

--- a/src/features/environmentDetails/environmentDetailsSlice.ts
+++ b/src/features/environmentDetails/environmentDetailsSlice.ts
@@ -11,12 +11,14 @@ export interface IEnvironmentDetailsState {
   mode: EnvironmentDetailsModes;
   name: string;
   prefix: string | null | undefined;
+  installedVersions: { [key: string]: string };
 }
 
 const initialState: IEnvironmentDetailsState = {
   mode: EnvironmentDetailsModes.READ,
   name: "",
-  prefix: null
+  prefix: null,
+  installedVersions: {}
 };
 
 export const environmentDetailsSlice = createSlice({
@@ -28,6 +30,12 @@ export const environmentDetailsSlice = createSlice({
       action: PayloadAction<IEnvironmentDetailsState["mode"]>
     ) => {
       state.mode = action.payload;
+    },
+    installedVersionsGenerated: (
+      state,
+      action: PayloadAction<IEnvironmentDetailsState["installedVersions"]>
+    ) => {
+      state.installedVersions = action.payload;
     }
   },
   extraReducers: builder => {
@@ -52,4 +60,5 @@ export const environmentDetailsSlice = createSlice({
   }
 });
 
-export const { modeChanged } = environmentDetailsSlice.actions;
+export const { modeChanged, installedVersionsGenerated } =
+  environmentDetailsSlice.actions;

--- a/src/features/environmentDetails/environmentDetailsSlice.ts
+++ b/src/features/environmentDetails/environmentDetailsSlice.ts
@@ -12,15 +12,13 @@ export interface IEnvironmentDetailsState {
   name: string;
   prefix: string | null | undefined;
   installedVersions: { [key: string]: string };
-  updatedConstraints: { [key: string]: { range: string; version: string } };
 }
 
 const initialState: IEnvironmentDetailsState = {
   mode: EnvironmentDetailsModes.READ,
   name: "",
   prefix: null,
-  installedVersions: {},
-  updatedConstraints: {}
+  installedVersions: {}
 };
 
 export const environmentDetailsSlice = createSlice({
@@ -38,24 +36,6 @@ export const environmentDetailsSlice = createSlice({
       action: PayloadAction<IEnvironmentDetailsState["installedVersions"]>
     ) => {
       state.installedVersions = action.payload;
-    },
-    constraintUpdated: (
-      state,
-      action: PayloadAction<{
-        pkgName: string;
-        pkgVersion: string;
-        pkgConstraint: string;
-      }>
-    ) => {
-      const { pkgName, pkgConstraint, pkgVersion } = action.payload;
-
-      state.updatedConstraints[pkgName] = {
-        range: pkgConstraint,
-        version: pkgVersion
-      };
-    },
-    constraintsCleared: state => {
-      state.updatedConstraints = {};
     }
   },
   extraReducers: builder => {
@@ -80,9 +60,5 @@ export const environmentDetailsSlice = createSlice({
   }
 });
 
-export const {
-  modeChanged,
-  installedVersionsGenerated,
-  constraintUpdated,
-  constraintsCleared
-} = environmentDetailsSlice.actions;
+export const { modeChanged, installedVersionsGenerated } =
+  environmentDetailsSlice.actions;

--- a/src/features/environmentDetails/environmentDetailsSlice.ts
+++ b/src/features/environmentDetails/environmentDetailsSlice.ts
@@ -53,6 +53,9 @@ export const environmentDetailsSlice = createSlice({
         range: pkgConstraint,
         version: pkgVersion
       };
+    },
+    constraintsCleared: state => {
+      state.updatedConstraints = {};
     }
   },
   extraReducers: builder => {
@@ -77,5 +80,9 @@ export const environmentDetailsSlice = createSlice({
   }
 });
 
-export const { modeChanged, installedVersionsGenerated, constraintUpdated } =
-  environmentDetailsSlice.actions;
+export const {
+  modeChanged,
+  installedVersionsGenerated,
+  constraintUpdated,
+  constraintsCleared
+} = environmentDetailsSlice.actions;

--- a/src/features/environmentDetails/environmentDetailsSlice.ts
+++ b/src/features/environmentDetails/environmentDetailsSlice.ts
@@ -12,13 +12,15 @@ export interface IEnvironmentDetailsState {
   name: string;
   prefix: string | null | undefined;
   installedVersions: { [key: string]: string };
+  updatedConstraints: { [key: string]: { range: string; version: string } };
 }
 
 const initialState: IEnvironmentDetailsState = {
   mode: EnvironmentDetailsModes.READ,
   name: "",
   prefix: null,
-  installedVersions: {}
+  installedVersions: {},
+  updatedConstraints: {}
 };
 
 export const environmentDetailsSlice = createSlice({
@@ -36,6 +38,21 @@ export const environmentDetailsSlice = createSlice({
       action: PayloadAction<IEnvironmentDetailsState["installedVersions"]>
     ) => {
       state.installedVersions = action.payload;
+    },
+    constraintUpdated: (
+      state,
+      action: PayloadAction<{
+        pkgName: string;
+        pkgVersion: string;
+        pkgConstraint: string;
+      }>
+    ) => {
+      const { pkgName, pkgConstraint, pkgVersion } = action.payload;
+
+      state.updatedConstraints[pkgName] = {
+        range: pkgConstraint,
+        version: pkgVersion
+      };
     }
   },
   extraReducers: builder => {
@@ -60,5 +77,5 @@ export const environmentDetailsSlice = createSlice({
   }
 });
 
-export const { modeChanged, installedVersionsGenerated } =
+export const { modeChanged, installedVersionsGenerated, constraintUpdated } =
   environmentDetailsSlice.actions;

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -22,7 +22,7 @@ interface IEnvMetadataProps {
    * @param onUpdateDescription change environment description
    */
   selectedEnv: any;
-  description: any;
+  description?: any;
   mode: "create" | "read-only" | "edit";
   onUpdateDescription: (description: string) => void;
   current_build_id: number;
@@ -30,7 +30,7 @@ interface IEnvMetadataProps {
 
 export const EnvMetadata = ({
   selectedEnv,
-  description,
+  description = "",
   mode,
   onUpdateDescription,
   current_build_id

--- a/src/features/requestedPackages/components/AddRequestedPackage.tsx
+++ b/src/features/requestedPackages/components/AddRequestedPackage.tsx
@@ -130,7 +130,7 @@ export const AddRequestedPackage = ({
 
   return (
     <Box sx={{ display: "flex", alignItems: "center", marginTop: "15px" }}>
-      <Box sx={{ marginRight: "160px" }}>
+      <Box sx={{ marginRight: isCreating ? "20px" : "160px" }}>
         <Autocomplete
           onInputChange={(event, value, reason) => {
             if (reason === "clear") {

--- a/src/features/requestedPackages/components/AddRequestedPackage.tsx
+++ b/src/features/requestedPackages/components/AddRequestedPackage.tsx
@@ -130,7 +130,7 @@ export const AddRequestedPackage = ({
 
   return (
     <Box sx={{ display: "flex", alignItems: "center", marginTop: "15px" }}>
-      <Box sx={{ marginRight: isCreating ? "20px" : "160px" }}>
+      <Box sx={{ marginRight: isCreating ? "158px" : "160px" }}>
         <Autocomplete
           onInputChange={(event, value, reason) => {
             if (reason === "clear") {

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import Box from "@mui/material/Box";
@@ -7,8 +8,6 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import useTheme from "@mui/material/styles/useTheme";
-import React, { useEffect, useMemo, useRef, useState } from "react";
-
 import { RequestedPackagesTableRow } from "./RequestedPackagesTableRow";
 import { AddRequestedPackage } from "./AddRequestedPackage";
 import {

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -20,69 +20,31 @@ import {
   StyledEditPackagesTableCell
 } from "../../../styles";
 import { CondaSpecificationPip } from "../../../common/models";
-import { requestedPackageParser } from "../../../utils/helpers";
+import { useAppDispatch } from "../../../hooks";
+import { packageAdded } from "../requestedPackagesSlice";
 
 export interface IRequestedPackagesEditProps {
   /**
    * @param packageList list of packages that we get from the API
-   * @param updatePackages notify the parent if there are changes in packageList array.
    */
   packageList: (string | CondaSpecificationPip)[];
-  updatePackages: (packages: string[]) => void;
 }
 
 export const RequestedPackagesEdit = ({
-  packageList,
-  updatePackages
+  packageList
 }: IRequestedPackagesEditProps) => {
-  const [data, setData] = useState(packageList);
+  const dispatch = useAppDispatch();
   const [isAdding, setIsAdding] = useState(false);
   const { palette } = useTheme();
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  const removePackage = (packageName: string) => {
-    const filteredList = (currentData: string[]) =>
-      currentData.filter(item => item !== packageName);
-
-    setData(filteredList);
-    const newArr = data.filter(item => item !== packageName) as string[];
-    updatePackages(newArr);
-  };
-
-  const addNewPackage = (packageName: string) => {
-    const newArr = [...data, packageName] as string[];
-    setData([...data, packageName]);
-    updatePackages(newArr);
-  };
-
-  const comparePackages = (
-    requestedPackage: string | CondaSpecificationPip,
-    newPackage: string,
-    newPackageName: string | CondaSpecificationPip
-  ) => {
-    const { name } = requestedPackageParser(requestedPackage as string);
-
-    if (name === newPackageName) {
-      return newPackage;
-    }
-
-    return requestedPackage;
-  };
-
-  const updatePackage = (name: string, constraint: string, version: string) => {
-    const newPackage = `${name}${constraint === "latest" ? ">=" : constraint}${
-      !version ? "" : version
-    }`;
-
-    const newArr = data
-      .filter(p => typeof p !== "object")
-      .map(p => comparePackages(p, newPackage, name)) as string[];
-    updatePackages(newArr);
+  const handleSubmit = (packageName: string) => {
+    dispatch(packageAdded(packageName));
   };
 
   const filteredPackageList = useMemo(
-    () => data.filter(item => typeof item !== "object"),
-    [data]
+    () => packageList.filter(item => typeof item !== "object"),
+    [packageList]
   );
 
   useEffect(() => {
@@ -90,10 +52,6 @@ export const RequestedPackagesEdit = ({
       scrollRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [isAdding]);
-
-  useEffect(() => {
-    setData(packageList);
-  }, [packageList]);
 
   return (
     <Accordion
@@ -152,8 +110,6 @@ export const RequestedPackagesEdit = ({
           <TableBody>
             {filteredPackageList.map(requestedPackage => (
               <RequestedPackagesTableRow
-                onUpdate={updatePackage}
-                onRemove={removePackage}
                 key={`${requestedPackage}`}
                 requestedPackage={`${requestedPackage}`}
               />
@@ -163,7 +119,7 @@ export const RequestedPackagesEdit = ({
         <Box ref={scrollRef}>
           {isAdding && (
             <AddRequestedPackage
-              onSubmit={addNewPackage}
+              onSubmit={handleSubmit}
               onCancel={setIsAdding}
               isCreating={false}
             />

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -26,17 +26,14 @@ export interface IRequestedPackagesEditProps {
   /**
    * @param packageList list of packages that we get from the API
    * @param updatePackages notify the parent if there are changes in packageList array.
-   * @param isCreating notify the component if it's being used for creation or edition.
    */
   packageList: (string | CondaSpecificationPip)[];
   updatePackages: (packages: string[]) => void;
-  isCreating: boolean;
 }
 
 export const RequestedPackagesEdit = ({
   packageList,
-  updatePackages,
-  isCreating
+  updatePackages
 }: IRequestedPackagesEditProps) => {
   const [data, setData] = useState(packageList);
   const [isAdding, setIsAdding] = useState(false);
@@ -129,21 +126,19 @@ export const RequestedPackagesEdit = ({
                   Name
                 </Typography>
               </StyledEditPackagesTableCell>
-              {!isCreating && (
-                <StyledEditPackagesTableCell
-                  align="left"
-                  sx={{
-                    width: "180px"
-                  }}
+              <StyledEditPackagesTableCell
+                align="left"
+                sx={{
+                  width: "180px"
+                }}
+              >
+                <Typography
+                  component="p"
+                  sx={{ fontSize: "16px", fontWeight: 500 }}
                 >
-                  <Typography
-                    component="p"
-                    sx={{ fontSize: "16px", fontWeight: 500 }}
-                  >
-                    Installed Version
-                  </Typography>
-                </StyledEditPackagesTableCell>
-              )}
+                  Installed Version
+                </Typography>
+              </StyledEditPackagesTableCell>
               <StyledEditPackagesTableCell align="left">
                 <Typography
                   component="p"
@@ -161,7 +156,6 @@ export const RequestedPackagesEdit = ({
                 onRemove={removePackage}
                 key={`${requestedPackage}`}
                 requestedPackage={`${requestedPackage}`}
-                isCreating={isCreating}
               />
             ))}
           </TableBody>
@@ -171,7 +165,7 @@ export const RequestedPackagesEdit = ({
             <AddRequestedPackage
               onSubmit={addNewPackage}
               onCancel={setIsAdding}
-              isCreating={isCreating}
+              isCreating={false}
             />
           )}
         </Box>

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -42,7 +42,7 @@ export const RequestedPackagesEdit = ({
   };
 
   const filteredPackageList = useMemo(
-    () => packageList.filter(item => typeof item !== "object"),
+    () => packageList.filter(item => typeof item !== "object") as string[],
     [packageList]
   );
 
@@ -109,8 +109,8 @@ export const RequestedPackagesEdit = ({
           <TableBody>
             {filteredPackageList.map(requestedPackage => (
               <RequestedPackagesTableRow
-                key={`${requestedPackage}`}
-                requestedPackage={`${requestedPackage}`}
+                key={requestedPackage}
+                requestedPackage={requestedPackage}
               />
             ))}
           </TableBody>

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -20,7 +20,7 @@ interface IRequestedPackagesTableRowProps {
   requestedPackage: string;
 }
 
-export const RequestedPackagesTableRow = ({
+const BaseRequestedPackagesTableRow = ({
   requestedPackage
 }: IRequestedPackagesTableRowProps) => {
   const dispatch = useAppDispatch();
@@ -90,3 +90,5 @@ export const RequestedPackagesTableRow = ({
     </TableRow>
   );
 };
+
+export const RequestedPackagesTableRow = memo(BaseRequestedPackagesTableRow);

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -11,7 +11,8 @@ import {
 import { ConstraintSelect, VersionSelect } from "../../../components";
 import { requestedPackageParser } from "../../../utils/helpers";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
-import { packageRemoved, packageUpdated } from "../requestedPackagesSlice";
+import { packageRemoved } from "../requestedPackagesSlice";
+import { constraintUpdated } from "../../environmentDetails";
 
 interface IRequestedPackagesTableRowProps {
   /**
@@ -25,7 +26,7 @@ const BaseRequestedPackagesTableRow = ({
 }: IRequestedPackagesTableRowProps) => {
   const dispatch = useAppDispatch();
   const { packageVersions } = useAppSelector(state => state.requestedPackages);
-  const { installedVersions } = useAppSelector(
+  const { installedVersions, updatedConstraints } = useAppSelector(
     state => state.environmentDetails
   );
 
@@ -44,18 +45,29 @@ const BaseRequestedPackagesTableRow = ({
       pkgConstraint = "";
     }
 
-    const updatedPackage = `${name}${pkgConstraint}${value}`;
-
     dispatch(
-      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
+      constraintUpdated({
+        pkgName: name,
+        pkgConstraint: pkgConstraint,
+        pkgVersion: value
+      })
     );
   };
 
   const updateConstraint = (value: string) => {
-    const updatedPackage = `${name}${value}${version}`;
+    let pkgVersion = version;
+    const updatedConstraint = updatedConstraints[name];
+
+    if (updatedConstraint) {
+      pkgVersion = updatedConstraint.version;
+    }
 
     dispatch(
-      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
+      constraintUpdated({
+        pkgName: name,
+        pkgConstraint: value,
+        pkgVersion
+      })
     );
   };
 

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -16,19 +16,16 @@ interface IRequestedPackagesTableRowProps {
   /**
    * @param requestedPackage requested package
    * @param onRemove handler that will run when delete icon is clicked
-   * @param isCreating notify the component if it's being used for creating or editing environment
    */
   requestedPackage: string;
   onRemove: (packageName: string) => void;
   onUpdate?: (name: string, constraint: string, version: string) => void;
-  isCreating: boolean;
 }
 
 export const RequestedPackagesTableRow = ({
   requestedPackage,
   onRemove,
-  onUpdate = (name: string, constraint: string, version: string) => {},
-  isCreating
+  onUpdate = (name: string, constraint: string, version: string) => {}
 }: IRequestedPackagesTableRowProps) => {
   const { packageVersions } = useAppSelector(state => state.requestedPackages);
 
@@ -55,15 +52,13 @@ export const RequestedPackagesTableRow = ({
           {name}
         </Typography>
       </StyledRequestedPackagesTableCell>
-      {!isCreating && (
-        <StyledRequestedPackagesTableCell align="left">
-          <Typography
-            sx={{ fontSize: "16px", fontWeight: 400, color: "#676666" }}
-          >
-            {version}
-          </Typography>
-        </StyledRequestedPackagesTableCell>
-      )}
+      <StyledRequestedPackagesTableCell align="left">
+        <Typography
+          sx={{ fontSize: "16px", fontWeight: 400, color: "#676666" }}
+        >
+          {version}
+        </Typography>
+      </StyledRequestedPackagesTableCell>
       <StyledRequestedPackagesTableCell align="left">
         <Box sx={{ display: "flex", alignItems: "center" }}>
           <ConstraintSelect

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -1,18 +1,16 @@
-import React, { memo } from "react";
-import TableRow from "@mui/material/TableRow";
-import Typography from "@mui/material/Typography";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Box from "@mui/material/Box";
-
-import {
-  StyledRequestedPackagesTableCell,
-  StyledIconButton
-} from "../../../styles";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import React, { memo } from "react";
 import { ConstraintSelect, VersionSelect } from "../../../components";
-import { requestedPackageParser } from "../../../utils/helpers";
 import { useAppDispatch, useAppSelector } from "../../../hooks";
-import { packageRemoved } from "../requestedPackagesSlice";
-import { constraintUpdated } from "../../environmentDetails";
+import {
+  StyledIconButton,
+  StyledRequestedPackagesTableCell
+} from "../../../styles";
+import { requestedPackageParser } from "../../../utils/helpers";
+import { packageRemoved, packageUpdated } from "../requestedPackagesSlice";
 
 interface IRequestedPackagesTableRowProps {
   /**
@@ -26,10 +24,9 @@ const BaseRequestedPackagesTableRow = ({
 }: IRequestedPackagesTableRowProps) => {
   const dispatch = useAppDispatch();
   const { packageVersions } = useAppSelector(state => state.requestedPackages);
-  const { installedVersions, updatedConstraints } = useAppSelector(
+  const { installedVersions } = useAppSelector(
     state => state.environmentDetails
   );
-
   const result = requestedPackageParser(requestedPackage);
   let { version } = result;
   const { constraint, name } = result;
@@ -45,29 +42,18 @@ const BaseRequestedPackagesTableRow = ({
       pkgConstraint = "";
     }
 
+    const updatedPackage = `${name}${pkgConstraint}${value}`;
+
     dispatch(
-      constraintUpdated({
-        pkgName: name,
-        pkgConstraint: pkgConstraint,
-        pkgVersion: value
-      })
+      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
     );
   };
 
   const updateConstraint = (value: string) => {
-    let pkgVersion = version;
-    const updatedConstraint = updatedConstraints[name];
-
-    if (updatedConstraint) {
-      pkgVersion = updatedConstraint.version;
-    }
+    const updatedPackage = `${name}${value}${version}`;
 
     dispatch(
-      constraintUpdated({
-        pkgName: name,
-        pkgConstraint: value,
-        pkgVersion
-      })
+      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
     );
   };
 

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -38,9 +38,13 @@ const BaseRequestedPackagesTableRow = ({
   }
 
   const updateVersion = (value: string) => {
-    const updatedPackage = `${name}${
-      constraint === "latest" ? ">=" : constraint
-    }${value}`;
+    let pkgConstraint = constraint === "latest" ? ">=" : constraint;
+
+    if (value === "") {
+      pkgConstraint = "";
+    }
+
+    const updatedPackage = `${name}${pkgConstraint}${value}`;
 
     dispatch(
       packageUpdated({ currentPackage: requestedPackage, updatedPackage })

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -10,23 +10,20 @@ import {
 } from "../../../styles";
 import { ConstraintSelect, VersionSelect } from "../../../components";
 import { requestedPackageParser } from "../../../utils/helpers";
-import { useAppSelector } from "../../../hooks";
+import { useAppDispatch, useAppSelector } from "../../../hooks";
+import { packageRemoved, packageUpdated } from "../requestedPackagesSlice";
 
 interface IRequestedPackagesTableRowProps {
   /**
    * @param requestedPackage requested package
-   * @param onRemove handler that will run when delete icon is clicked
    */
   requestedPackage: string;
-  onRemove: (packageName: string) => void;
-  onUpdate?: (name: string, constraint: string, version: string) => void;
 }
 
 export const RequestedPackagesTableRow = ({
-  requestedPackage,
-  onRemove,
-  onUpdate = (name: string, constraint: string, version: string) => {}
+  requestedPackage
 }: IRequestedPackagesTableRowProps) => {
+  const dispatch = useAppDispatch();
   const { packageVersions } = useAppSelector(state => state.requestedPackages);
 
   const result = requestedPackageParser(requestedPackage);
@@ -38,12 +35,24 @@ export const RequestedPackagesTableRow = ({
   }
 
   const updateVersion = (value: string) => {
-    onUpdate(name, constraint, value);
+    const updatedPackage = `${name}${
+      constraint === "latest" ? ">=" : constraint
+    }${value}`;
+
+    dispatch(
+      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
+    );
   };
 
   const updateConstraint = (value: string) => {
-    onUpdate(name, value, version);
+    const updatedPackage = `${name}${value}${version}`;
+
+    dispatch(
+      packageUpdated({ currentPackage: requestedPackage, updatedPackage })
+    );
   };
+
+  const handleRemove = () => dispatch(packageRemoved(requestedPackage));
 
   return (
     <TableRow>
@@ -70,10 +79,7 @@ export const RequestedPackagesTableRow = ({
             version={constraint === "latest" ? "" : version}
             name={name}
           />
-          <StyledIconButton
-            onClick={() => onRemove(requestedPackage)}
-            sx={{ marginLeft: "24px" }}
-          >
+          <StyledIconButton onClick={handleRemove} sx={{ marginLeft: "24px" }}>
             <DeleteIcon />
           </StyledIconButton>
         </Box>

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -25,6 +25,9 @@ export const RequestedPackagesTableRow = ({
 }: IRequestedPackagesTableRowProps) => {
   const dispatch = useAppDispatch();
   const { packageVersions } = useAppSelector(state => state.requestedPackages);
+  const { installedVersions } = useAppSelector(
+    state => state.environmentDetails
+  );
 
   const result = requestedPackageParser(requestedPackage);
   let { version } = result;
@@ -65,7 +68,7 @@ export const RequestedPackagesTableRow = ({
         <Typography
           sx={{ fontSize: "16px", fontWeight: 400, color: "#676666" }}
         >
-          {version}
+          {installedVersions[name]}
         </Typography>
       </StyledRequestedPackagesTableCell>
       <StyledRequestedPackagesTableCell align="left">

--- a/src/features/requestedPackages/requestedPackagesSlice.ts
+++ b/src/features/requestedPackages/requestedPackagesSlice.ts
@@ -1,6 +1,10 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-import { CondaSpecificationPip, Dependency } from "../../common/models";
+import {
+  BuildPackage,
+  CondaSpecificationPip,
+  Dependency
+} from "../../common/models";
 import { requestedPackageParser } from "../../utils/helpers";
 import { environmentDetailsApiSlice } from "../environmentDetails";
 
@@ -8,12 +12,16 @@ export interface IRequestedPackagesState {
   requestedPackages: (string | CondaSpecificationPip)[];
   packageVersions: { [key: string]: string };
   packagesWithLatestVersions: { [key: string]: string };
+  buildPackagesCache: {
+    [key: string]: { packages: BuildPackage[]; count: number };
+  };
 }
 
 const initialState: IRequestedPackagesState = {
   requestedPackages: [],
   packageVersions: {},
-  packagesWithLatestVersions: {}
+  packagesWithLatestVersions: {},
+  buildPackagesCache: {}
 };
 
 export const requestedPackagesSlice = createSlice({
@@ -54,6 +62,18 @@ export const requestedPackagesSlice = createSlice({
     },
     packageAdded: (state, action: PayloadAction<string>) => {
       state.requestedPackages.push(action.payload);
+    },
+    buildPackagesCacheAdded: (
+      state,
+      action: PayloadAction<{
+        pkgName: string;
+        packages: BuildPackage[];
+        count: number;
+      }>
+    ) => {
+      const { pkgName, packages, count } = action.payload;
+
+      state.buildPackagesCache[pkgName] = { packages, count };
     }
   },
   extraReducers: builder => {
@@ -93,5 +113,6 @@ export const {
   dependencyPromoted,
   packageUpdated,
   packageRemoved,
-  packageAdded
+  packageAdded,
+  buildPackagesCacheAdded
 } = requestedPackagesSlice.actions;

--- a/src/features/requestedPackages/requestedPackagesSlice.ts
+++ b/src/features/requestedPackages/requestedPackagesSlice.ts
@@ -36,6 +36,24 @@ export const requestedPackagesSlice = createSlice({
       const newRequestedPackage = `${action.payload.name}==${action.payload.version}`;
 
       state.requestedPackages.push(newRequestedPackage);
+    },
+    packageUpdated: (
+      state,
+      action: PayloadAction<{ currentPackage: string; updatedPackage: string }>
+    ) => {
+      const { currentPackage, updatedPackage } = action.payload;
+
+      state.requestedPackages = state.requestedPackages.map(p =>
+        p === currentPackage ? updatedPackage : p
+      );
+    },
+    packageRemoved: (state, action: PayloadAction<string>) => {
+      state.requestedPackages = state.requestedPackages.filter(
+        p => p !== action.payload
+      );
+    },
+    packageAdded: (state, action: PayloadAction<string>) => {
+      state.requestedPackages.push(action.payload);
     }
   },
   extraReducers: builder => {
@@ -69,5 +87,11 @@ export const requestedPackagesSlice = createSlice({
   }
 });
 
-export const { packageVersionAdded, updatePackages, dependencyPromoted } =
-  requestedPackagesSlice.actions;
+export const {
+  packageVersionAdded,
+  updatePackages,
+  dependencyPromoted,
+  packageUpdated,
+  packageRemoved,
+  packageAdded
+} = requestedPackagesSlice.actions;

--- a/src/features/requestedPackages/stories/RequestedPackagesEdit.stories.tsx
+++ b/src/features/requestedPackages/stories/RequestedPackagesEdit.stories.tsx
@@ -14,8 +14,5 @@ export default {
 } as ComponentMeta<typeof RequestedPackagesEdit>;
 
 export const Primary: ComponentStory<typeof RequestedPackagesEdit> = () => (
-  <RequestedPackagesEdit
-    packageList={packageList}
-    updatePackages={() => ({})}
-  />
+  <RequestedPackagesEdit packageList={packageList} />
 );

--- a/src/features/requestedPackages/stories/RequestedPackagesEdit.stories.tsx
+++ b/src/features/requestedPackages/stories/RequestedPackagesEdit.stories.tsx
@@ -17,6 +17,5 @@ export const Primary: ComponentStory<typeof RequestedPackagesEdit> = () => (
   <RequestedPackagesEdit
     packageList={packageList}
     updatePackages={() => ({})}
-    isCreating={false}
   />
 );

--- a/src/features/yamlEditor/components/editor.tsx
+++ b/src/features/yamlEditor/components/editor.tsx
@@ -7,7 +7,10 @@ import { parse } from "yaml";
 
 export interface ICodeEditor {
   code: any;
-  onChangeEditor: (str: any) => void;
+  onChangeEditor: (code: {
+    channels: string[];
+    dependencies: string[];
+  }) => void;
 }
 
 export const CodeEditor = ({ code, onChangeEditor }: ICodeEditor) => {

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -5,6 +5,7 @@ import { environmentDetailsSlice } from "../features/environmentDetails";
 import { requestedPackagesSlice } from "../features/requestedPackages";
 import { tabsSlice } from "../features/tabs";
 import { enviromentsSlice } from "../features/metadata";
+import { environmentCreateSlice } from "../features/environmentCreate/environmentCreateSlice";
 
 export const rootReducer = {
   [apiSlice.reducerPath]: apiSlice.reducer,
@@ -13,5 +14,6 @@ export const rootReducer = {
   tabs: tabsSlice.reducer,
   enviroments: enviromentsSlice.reducer,
   environmentDetails: environmentDetailsSlice.reducer,
-  dependencies: dependenciesSlice.reducer
+  dependencies: dependenciesSlice.reducer,
+  environmentCreate: environmentCreateSlice.reducer
 };

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./reorderArray";
 export * from "./requestedPackageParser";
 export * from "./buildMapper";
+export * from "./updatePackagesWithConstraints";

--- a/src/utils/helpers/updatePackagesWithConstraints.ts
+++ b/src/utils/helpers/updatePackagesWithConstraints.ts
@@ -1,0 +1,26 @@
+import { CondaSpecificationPip } from "../../common/models";
+import { requestedPackageParser } from "./requestedPackageParser";
+
+export const updatePackagesWithConstraints = (
+  updatedConstraints: {
+    [key: string]: { range: string; version: string };
+  },
+  requestedPackages: (string | CondaSpecificationPip)[]
+) => {
+  const updatedPackageList = requestedPackages.map(p => {
+    if (typeof p === "object") {
+      return p;
+    }
+
+    const { name } = requestedPackageParser(p as string);
+    const updatedConstraint = updatedConstraints[name];
+
+    if (updatedConstraint) {
+      return `${name}${updatedConstraint.range}${updatedConstraint.version}`;
+    }
+
+    return p;
+  });
+
+  return updatedPackageList;
+};


### PR DESCRIPTION
Note for @telamonian 

There were a lot of bugs that emerged from environment creation and edition functionality. What I tried to accomplish with this PR is to remove some of the prop drilling and heavy local state that we had and move that in redux so we can have a bit easier time extending things and having fewer bugs. There were cases where one component was doing things that it should not be responsible for and it was hard to develop it or prevent bugs since there were many props drilled and it was used in multiple places. 
I was not able to do everything exactly how I would want it since the app was growing on the old code for weeks.
