### PR TITLE
Add gha to build/push image to ghcr

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,58 @@
+name: "Build and Push Image"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - ".github/workflows/build-push-image.yml"
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  security-events: write
+
+jobs:
+  build-image:
+    name: "Build Image"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v2
+
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: "Generate image tags"
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          image: |
+            "ghcr.io/${{ github.repository_owner }}/conda-store-ui"
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: "Build docker image"
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          # Push to GHCR only on commit to `main`
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GH_TOKEN }}
 
       - name: "Generate image tags"
         id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM node:16.16-alpine3.15
 
 WORKDIR /usr/src/app
 
-COPY package*.json .
-
-RUN yarn install 
-
 COPY . .
+
+RUN yarn install
 
 RUN mv .env.example .env
 


### PR DESCRIPTION
This PR adds a Github-Action that builds and pushes the conda-store-ui image to GHCR. 

> NOTE: the push will only be triggered on commits to `main`, building the image will occur on all PRs that touch the dockerfile or workflow file.

This action requires an access token that will need to be added as a secret: `GHCR_TOKEN` 
Something I don't have permissions to do.

Lastly, when the GHCR registry is first created, it is private, we will just need to flip it over to public. 

cc @pierrotsmnrd 