### PR TITLE
Extend yarn timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN yarn install
+RUN yarn install --network-timeout 600000
 
 RUN mv .env.example .env
 


### PR DESCRIPTION
Extend yarn timeout to avoid `There appears to be trouble with your network connection. Retrying...` warnings messages and failures when running the docker stack