### PR TITLE
fix #93 : List of packages names is incomplete

### DIFF
--- a/src/features/requestedPackages/requestedPackagesApiSlice.ts
+++ b/src/features/requestedPackages/requestedPackagesApiSlice.ts
@@ -9,7 +9,7 @@ export const requestedPackagesApiSlice = apiSlice.injectEndpoints({
       { page: number; size: number; search: string }
     >({
       query: dto =>
-        `api/v1/package?search=${dto.search}&page=${dto.page}&size=${dto.size}`
+        `api/v1/package?search=${dto.search}&page=${dto.page}&size=${dto.size}&distinct_on=name`
     })
   })
 });


### PR DESCRIPTION
The fix uses an API parameter that makes the results be distinct on names, so no more partial results and need to parse multiple pages.

This works with the current version of conda-store (0.4.12) as well as the next release with DB rework and performances improvements.