### PR TITLE
Fix blank page & update specification area when a new env is created

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -18,7 +18,7 @@ export const Popup = ({ description, isVisible, onClose }: IPopupInterface) => {
   return (
     <Snackbar
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-      autoHideDuration={5000}
+      autoHideDuration={3000}
       open={isVisible}
       onClose={handleClose}
     >

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -114,7 +114,6 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
       )}
       <Box sx={{ marginBottom: "30px" }}>
         <EnvMetadata
-          current_build_id={0}
           mode={mode}
           onUpdateDescription={handleChangeDescription}
         />

--- a/src/features/metadata/components/BuildDropdown.tsx
+++ b/src/features/metadata/components/BuildDropdown.tsx
@@ -7,7 +7,7 @@ import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import IconButton from "@mui/material/IconButton";
 import { StyledMetadataItem } from "../../../styles/StyledMetadataItem";
 import { useAppDispatch } from "../../../hooks";
-import { currentBuildIdChanged, buildStatusChanged } from "..";
+import { currentBuildIdChanged } from "..";
 import { getStylesForStyleType } from "../../../utils/helpers";
 import { Typography } from "@mui/material";
 
@@ -64,7 +64,6 @@ export const Build = ({
   useEffect(() => {
     const build = builds.find(build => build.id === selectedBuildId);
     if (build) {
-      dispatch(buildStatusChanged(build.status));
       setStatus(build.status);
     }
   }, [builds]);
@@ -76,7 +75,6 @@ export const Build = ({
 
     if (newCurrentBuild) {
       dispatch(currentBuildIdChanged(newCurrentBuild.id));
-      dispatch(buildStatusChanged(newCurrentBuild.status));
       setStatus(newCurrentBuild.status);
     }
   };

--- a/src/features/metadata/components/BuildDropdown.tsx
+++ b/src/features/metadata/components/BuildDropdown.tsx
@@ -8,7 +8,6 @@ import IconButton from "@mui/material/IconButton";
 import { StyledMetadataItem } from "../../../styles/StyledMetadataItem";
 import { useAppDispatch } from "../../../hooks";
 import { currentBuildIdChanged, buildStatusChanged } from "..";
-import { useAppSelector } from "../../../hooks";
 import { getStylesForStyleType } from "../../../utils/helpers";
 import { Typography } from "@mui/material";
 
@@ -23,17 +22,16 @@ interface IBuildProps {
     name: string;
     status: string;
   }[];
-  currentBuildId: number;
+  selectedBuildId: number;
   currentBuildStatus: string;
 }
 
 export const Build = ({
   builds,
-  currentBuildId,
+  selectedBuildId,
   currentBuildStatus
 }: IBuildProps) => {
   const dispatch = useAppDispatch();
-  const { currentBuild } = useAppSelector(state => state.enviroments);
   const { palette } = useTheme();
   const [open, setOpen] = useState(false);
   const [status, setStatus] = useState(currentBuildStatus);
@@ -64,13 +62,10 @@ export const Build = ({
 
   // If the user is watching his current build, update build's info
   useEffect(() => {
-    if (["Queued", "Building"].includes(status)) {
-      const id = builds.length === 1 ? currentBuildId : currentBuild.id;
-      const build = builds.find(build => build.id === id);
-      if (build) {
-        setStatus(build.status);
-        dispatch(buildStatusChanged(build.status));
-      }
+    const build = builds.find(build => build.id === selectedBuildId);
+    if (build) {
+      dispatch(buildStatusChanged(build.status));
+      setStatus(build.status);
     }
   }, [builds]);
 
@@ -81,8 +76,8 @@ export const Build = ({
 
     if (newCurrentBuild) {
       dispatch(currentBuildIdChanged(newCurrentBuild.id));
-      setStatus(newCurrentBuild.status);
       dispatch(buildStatusChanged(newCurrentBuild.status));
+      setStatus(newCurrentBuild.status);
     }
   };
 
@@ -103,7 +98,7 @@ export const Build = ({
             }
           }
         }}
-        defaultValue={currentBuildId}
+        value={selectedBuildId}
         onChange={handleChange}
         IconComponent={() => (
           <IconButton

--- a/src/features/metadata/components/BuildDropdown.tsx
+++ b/src/features/metadata/components/BuildDropdown.tsx
@@ -137,9 +137,9 @@ export const Build = ({
           {status}
           {(status === "Building" || status === "Queued") && (
             <CircularProgress
-              size={15}
+              size={10}
               sx={{
-                marginLeft: "10px"
+                marginLeft: "8px"
               }}
             />
           )}

--- a/src/features/metadata/components/EnvBuilds.tsx
+++ b/src/features/metadata/components/EnvBuilds.tsx
@@ -8,9 +8,10 @@ import { getStylesForStyleType } from "../../../utils/helpers";
 
 interface IData {
   currentBuildId: number;
+  selectedBuildId: number;
 }
 
-export const EnvBuilds = ({ currentBuildId }: IData) => {
+export const EnvBuilds = ({ currentBuildId, selectedBuildId }: IData) => {
   const { builds } = useAppSelector(state => state.enviroments);
   const envBuilds = builds.length ? buildMapper(builds, currentBuildId) : [];
   const currentBuild = envBuilds.find(build => build.id === currentBuildId);
@@ -26,8 +27,8 @@ export const EnvBuilds = ({ currentBuildId }: IData) => {
       {currentBuild && (
         <Build
           builds={envBuilds}
-          currentBuildId={currentBuild.id}
           currentBuildStatus={currentBuild.status}
+          selectedBuildId={selectedBuildId}
         />
       )}
       {!currentBuild && (

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -19,14 +19,16 @@ interface IEnvMetadataProps {
    */
   description?: any;
   mode: "create" | "read-only" | "edit";
-  current_build_id: number | undefined;
+  currentBuildId?: number | undefined;
+  selectedBuildId?: number;
   onUpdateDescription: (description: string) => void;
 }
 
 export const EnvMetadata = ({
   mode,
   description = "",
-  current_build_id,
+  currentBuildId,
+  selectedBuildId,
   onUpdateDescription
 }: IEnvMetadataProps) => {
   return (
@@ -54,9 +56,14 @@ export const EnvMetadata = ({
         description={description || undefined}
         onChangeDescription={onUpdateDescription}
       />
-      {mode !== EnvironmentDetailsModes.CREATE && current_build_id && (
-        <EnvBuilds currentBuildId={current_build_id} />
-      )}
+      {mode !== EnvironmentDetailsModes.CREATE &&
+        currentBuildId &&
+        selectedBuildId && (
+          <EnvBuilds
+            currentBuildId={currentBuildId}
+            selectedBuildId={selectedBuildId}
+          />
+        )}
     </StyledBox>
   );
 };

--- a/src/features/metadata/metadataSlice.ts
+++ b/src/features/metadata/metadataSlice.ts
@@ -26,7 +26,10 @@ export const enviromentsSlice = createSlice({
   name: "environments",
   initialState,
   reducers: {
-    currentBuildIdChanged: (state, action: PayloadAction<number>) => {
+    currentBuildIdChanged: (
+      state,
+      action: PayloadAction<number | undefined>
+    ) => {
       state.currentBuild.id = action.payload;
     },
     buildStatusChanged: (state, action: PayloadAction<any>) => {

--- a/src/features/metadata/metadataSlice.ts
+++ b/src/features/metadata/metadataSlice.ts
@@ -9,7 +9,6 @@ export interface IBuildState {
   count: number;
   size: number;
   currentBuild: { id: number | undefined };
-  currentBuildStatus: string;
 }
 
 const initialState: IBuildState = {
@@ -18,8 +17,7 @@ const initialState: IBuildState = {
   page: 1,
   count: 0,
   size: 0,
-  currentBuild: { id: undefined },
-  currentBuildStatus: ""
+  currentBuild: { id: undefined }
 };
 
 export const enviromentsSlice = createSlice({
@@ -31,9 +29,6 @@ export const enviromentsSlice = createSlice({
       action: PayloadAction<number | undefined>
     ) => {
       state.currentBuild.id = action.payload;
-    },
-    buildStatusChanged: (state, action: PayloadAction<any>) => {
-      state.currentBuildStatus = action.payload;
     }
   },
   extraReducers: builder => {
@@ -52,5 +47,4 @@ export const enviromentsSlice = createSlice({
   }
 });
 
-export const { currentBuildIdChanged, buildStatusChanged } =
-  enviromentsSlice.actions;
+export const { currentBuildIdChanged } = enviromentsSlice.actions;

--- a/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesTableRow.tsx
@@ -51,7 +51,7 @@ const BaseRequestedPackagesTableRow = ({
   };
 
   const updateConstraint = (value: string) => {
-    const updatedPackage = `${name}${value}${version}`;
+    const updatedPackage = `${name}${value}${version ? version : ""}`;
 
     dispatch(
       packageUpdated({ currentPackage: requestedPackage, updatedPackage })

--- a/src/features/tabs/components/PageTabs.tsx
+++ b/src/features/tabs/components/PageTabs.tsx
@@ -13,6 +13,7 @@ import {
   closeCreateNewEnvironmentTab,
   toggleNewEnvironmentView
 } from "../tabsSlice";
+import { currentBuildIdChanged } from "../../metadata";
 
 export const PageTabs = () => {
   const { selectedEnvironments, value, selectedEnvironment, newEnvironment } =
@@ -45,6 +46,7 @@ export const PageTabs = () => {
           : envId
       })
     );
+    dispatch(currentBuildIdChanged(undefined));
     if (selectedEnvironments.length === 1 && newEnvironment.isOpen) {
       dispatch(modeChanged(EnvironmentDetailsModes.CREATE));
     }


### PR DESCRIPTION
- When a new env is created the dropdown should select the new build id and show the new specification data related.
- Avoid blank page when the version and constraint of the package are empty.
