### PR TITLE
Adding webpack bundle to push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,3 +13,9 @@ jobs:
       run: yarn
     - name: Run ESLint
       run: yarn eslint:check
+    - name: Build artifacts
+      run: yarn run webpack bundle
+    - uses: actions/upload-artifact@v3
+      with:
+        name: webpack-bundle
+        path: dist/


### PR DESCRIPTION
Add a CI process for generating build artifacts which can be then used by conda-store as assets.