### PR TITLE
Fix artifacts URL

### DIFF
--- a/src/features/artifacts/components/ArtifactsItem.tsx
+++ b/src/features/artifacts/components/ArtifactsItem.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import { Artifact } from "../../../common/models";
 import { PrefContext } from "../../../preferences";
+import { isPathAbsolute } from "../../../utils/helpers";
 
 interface IArtifactsProps {
   /**
@@ -14,7 +15,10 @@ interface IArtifactsProps {
 
 export const ArtifactItem = ({ artifact }: IArtifactsProps) => {
   const pref = React.useContext(PrefContext);
-  const route = new URL(artifact.route, pref.apiUrl).toString();
+  const url = isPathAbsolute(pref.apiUrl)
+    ? pref.apiUrl
+    : `${window.location.origin}${pref.apiUrl}`;
+  const route = new URL(artifact.route, url).toString();
 
   return (
     <Box sx={{ display: "flex", alignItems: "center" }}>

--- a/src/utils/helpers/artifact.ts
+++ b/src/utils/helpers/artifact.ts
@@ -20,11 +20,11 @@ const artifactList = (
     },
     LOGS: {
       name: `Conda Env ${currentBuildId} log`,
-      route: `api/v1/build/${currentBuildId}/logs`
+      route: `api/v1/build/${currentBuildId}/logs/`
     },
     DOCKER_MANIFEST: {
       name: "Docker image",
-      route: `$api/v1/build/${currentBuildId}/docker/`
+      route: `api/v1/build/${currentBuildId}/docker/`
     }
   };
 

--- a/src/utils/helpers/parseArtifactList.ts
+++ b/src/utils/helpers/parseArtifactList.ts
@@ -8,3 +8,7 @@ export const parseArtifacts = (artifact_list: string[] | undefined) => {
     return artifact_list.includes(artifact);
   });
 };
+
+export const isPathAbsolute = (path: string) => {
+  return new RegExp("^(?:[a-z]+:)?//", "i").test(path);
+};


### PR DESCRIPTION
When we set `REACT_APP_API_URL` with a relative path like `/conda-store/`, it will return the following error:

> TypeError: Failed to construct 'URL': Invalid base URL

That error happens because the second parameter of `new URL()` should be an absolute path.

To fix that issue, we need to identify when the `REACT_APP_API_URL` is relative. If yes, complete the URL structure, retrieving the existing one from the browser.