### PR TITLE
User's primary namespace

### DIFF
--- a/src/common/interfaces/NamespaceEnvironments.ts
+++ b/src/common/interfaces/NamespaceEnvironments.ts
@@ -3,4 +3,5 @@ import { Environment } from "../models";
 export interface INamespaceEnvironments {
   namespace: string;
   environments: Environment[];
+  isPrimary?: boolean;
 }

--- a/src/common/models/Namespace.ts
+++ b/src/common/models/Namespace.ts
@@ -1,4 +1,5 @@
 export type Namespace = {
-  id: number;
+  id: number | undefined;
   name: string;
+  isPrimary?: boolean;
 };

--- a/src/features/environments/components/EnvironmentsList.tsx
+++ b/src/features/environments/components/EnvironmentsList.tsx
@@ -9,8 +9,8 @@ import { GroupIconAlt } from "../../../components";
 import { StyledScrollContainer } from "../../../styles";
 import {
   getMyPrimaryNamespace,
-  groupEnvsByNamespace,
-  getSharedNamespaces
+  getSharedNamespaces,
+  namespaceMapper
 } from "../../../utils/helpers/namespaces";
 import { EnvironmentDropdown } from "./EnvironmentDropdown";
 
@@ -39,15 +39,12 @@ export const EnvironmentsList = ({
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const { primaryNamespace, sharedNamespaces } = useMemo(() => {
-    const myPrimaryNamespace = namespacesList.find(
-      namespace => namespace.isPrimary
+    // Group existing environments by namespace...
+    const envsGroupedByNamespace = namespaceMapper(
+      environmentsList,
+      namespacesList
     );
 
-    // Group existing environments by namespace...
-    const envsGroupedByNamespace = groupEnvsByNamespace(
-      environmentsList,
-      myPrimaryNamespace
-    );
     const primaryNamespace = getMyPrimaryNamespace(envsGroupedByNamespace);
     const sharedNamespaces = getSharedNamespaces(envsGroupedByNamespace);
 

--- a/src/features/environments/components/EnvironmentsList.tsx
+++ b/src/features/environments/components/EnvironmentsList.tsx
@@ -43,8 +43,6 @@ export const EnvironmentsList = ({
       namespace => namespace.isPrimary
     );
 
-    console.log(myPrimaryNamespace);
-
     // Group existing environments by namespace...
     const envsGroupedByNamespace = groupEnvsByNamespace(
       environmentsList,
@@ -52,8 +50,6 @@ export const EnvironmentsList = ({
     );
     const primaryNamespace = getMyPrimaryNamespace(envsGroupedByNamespace);
     const sharedNamespaces = getSharedNamespaces(envsGroupedByNamespace);
-
-    console.log(primaryNamespace, sharedNamespaces);
 
     return { primaryNamespace, sharedNamespaces };
   }, [environmentsList, namespacesList]);

--- a/src/features/namespaces/namespacesApiSlice.ts
+++ b/src/features/namespaces/namespacesApiSlice.ts
@@ -9,8 +9,14 @@ export const namespacesApiSlice = apiSlice.injectEndpoints({
       { page: number; size: number }
     >({
       query: dto => `/api/v1/namespace/?page=${dto.page}&size=${dto.size}`
+    }),
+    fetchPrimaryNamespace: builder.query<any, void>({
+      query: () => "/api/v1/permission/"
     })
   })
 });
 
-export const { useLazyFetchNamespacesQuery } = namespacesApiSlice;
+export const {
+  useLazyFetchNamespacesQuery,
+  useLazyFetchPrimaryNamespaceQuery
+} = namespacesApiSlice;

--- a/src/utils/helpers/namespaces.ts
+++ b/src/utils/helpers/namespaces.ts
@@ -47,7 +47,7 @@ export const checkMyPrimaryNamespace = (
  *
  * @param environmentsList - list of environments
  */
-const groupEnvsByNamespace = (environmentsList: Environment[]) => {
+export const groupEnvsByNamespace = (environmentsList: Environment[]) => {
   return environmentsList.reduce((acc: any, curr: any) => {
     if (!acc[curr.namespace.name]) {
       acc[curr.namespace.name] = [];

--- a/src/utils/helpers/namespaces.ts
+++ b/src/utils/helpers/namespaces.ts
@@ -1,0 +1,121 @@
+import { INamespaceEnvironments } from "../../common/interfaces";
+import { Environment, Namespace } from "../../common/models";
+
+/**
+ * Validate if my own namespace is already listed in the namespace array.
+ *
+ * @param list - list of namespaces
+ * @param primaryNamespace - primary namespace
+ * @returns true or false if the namespace is listed
+ */
+export const isNamespaceListed = (list: any, primaryNamespace: Namespace) => {
+  if (
+    primaryNamespace.name === "default" ||
+    list.some((item: Namespace) => item.name === primaryNamespace.name)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Identify which of the listed namespaces is my primary.
+ *
+ * @param list - list of namespaces
+ * @param primaryNamespace - primary namespace
+ * @returns an array with a new property called isPrimary
+ */
+export const checkMyPrimaryNamespace = (
+  list: any,
+  primaryNamespace: Namespace
+) => {
+  return list.map((item: { name: string }) => {
+    if (item.name === primaryNamespace.name) {
+      return {
+        ...item,
+        isPrimary: primaryNamespace.name !== "default"
+      };
+    }
+    return item;
+  });
+};
+
+/**
+ * Environments are grouped according to their own namespaces.
+ *
+ * @param environmentsList - list of environments
+ * @param primaryNamespace - primary namespace
+ * @returns a new array with namespace info
+ */
+export const groupEnvsByNamespace = (
+  environmentsList: Environment[],
+  primaryNamespace: Namespace | undefined
+): INamespaceEnvironments[] => {
+  return environmentsList.reduce((acc: any, curr: any) => {
+    // initialize with primary namespace
+    if (primaryNamespace && !acc[primaryNamespace.name]) {
+      acc[primaryNamespace.name] = {
+        isPrimary: true,
+        environments: [],
+        namespace: primaryNamespace.name
+      };
+    }
+    // set the initial value per each namespace
+    if (!acc[curr.namespace.name]) {
+      acc[curr.namespace.name] = {
+        namespace: curr.namespace.name,
+        environments: [],
+        isPrimary: true
+      };
+    }
+    // fill every position with current namespace data
+    acc[curr.namespace.name] = {
+      namespace: curr.namespace.name,
+      environments: [...acc[curr.namespace.name].environments, curr],
+      isPrimary: curr.namespace.name === primaryNamespace?.name
+    };
+    return acc;
+  }, {});
+};
+
+/**
+ * Return your primary namespace
+ *
+ * @param namespaces - list of namespaces
+ * @returns an object with your primary namespace info
+ */
+export const getMyPrimaryNamespace = (
+  namespaces: INamespaceEnvironments[]
+): INamespaceEnvironments | undefined => {
+  return Object.values(namespaces).find((namespace: INamespaceEnvironments) => {
+    if (namespace.isPrimary) {
+      return {
+        namespace: namespace.namespace,
+        environments: namespace.environments
+      };
+    }
+    return undefined;
+  });
+};
+
+/**
+ * Return your shared namespaces
+ *
+ * @param namespaces - list of namespaces
+ * @returns an array with your shared namespaces info
+ */
+export const getSharedNamespaces = (
+  namespaces: INamespaceEnvironments[]
+): INamespaceEnvironments[] => {
+  return Object.values(namespaces).filter(
+    (namespace: INamespaceEnvironments) => {
+      if (!namespace.isPrimary) {
+        return {
+          namespace: namespace.namespace,
+          environments: namespace.environments
+        };
+      }
+      return undefined;
+    }
+  );
+};

--- a/test/environments/EnvironmentList.test.tsx
+++ b/test/environments/EnvironmentList.test.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { Provider } from "react-redux";
 import { render } from "@testing-library/react";
 import { EnvironmentsList } from "../../src/features/environments";
-import { ENVIRONMENT, mockTheme } from "../testutils";
+import { ENVIRONMENT, ENVIRONMENTS, mockTheme } from "../testutils";
 import { store } from "../../src/store";
 
 describe("<EnvironmentsList />", () => {
   window.HTMLElement.prototype.scrollTo = jest.fn();
 
-  it("should display namespaces and their environments", () => {
+  it("should display primary namespace", () => {
     const component = render(
       mockTheme(
         <Provider store={store}>
@@ -16,20 +16,14 @@ describe("<EnvironmentsList />", () => {
             environmentsList={[
               {
                 ...ENVIRONMENT,
-                namespace: {
-                  id: 2,
-                  name: "new-shared-env"
-                }
+                namespace: { id: 2, name: "python-flask-env" }
               }
             ]}
             namespacesList={[
               {
-                name: "default",
-                id: 1
-              },
-              {
-                name: "shared-env",
-                id: 2
+                id: 2,
+                name: "python-flask-env",
+                isPrimary: true
               }
             ]}
             hasMore={false}
@@ -40,7 +34,30 @@ describe("<EnvironmentsList />", () => {
       )
     );
 
+    expect(component.container).toHaveTextContent("python-flask-env");
+  });
+
+  it("should display shared environments", () => {
+    const component = render(
+      mockTheme(
+        <Provider store={store}>
+          <EnvironmentsList
+            environmentsList={ENVIRONMENTS}
+            namespacesList={[
+              {
+                name: "default",
+                id: 1
+              }
+            ]}
+            hasMore={false}
+            next={jest.fn()}
+            search={""}
+          ></EnvironmentsList>
+        </Provider>
+      )
+    );
+
+    expect(component.container).toHaveTextContent("Shared environments");
     expect(component.container).toHaveTextContent("default");
-    expect(component.container).toHaveTextContent("python-flask-env-2");
   });
 });

--- a/test/environments/Environments.test.tsx
+++ b/test/environments/Environments.test.tsx
@@ -22,6 +22,17 @@ jest.mock("../../src/features/namespaces/namespacesApiSlice", () => ({
         ]
       }
     })
+  ]),
+  useLazyFetchPrimaryNamespaceQuery: jest.fn(() => [
+    () => ({
+      data: {
+        data: [
+          {
+            primary_namespace: "admin"
+          }
+        ]
+      }
+    })
   ])
 }));
 jest.mock("../../src/features/environments/environmentsApiSlice", () => ({

--- a/test/environments/Environments.test.tsx
+++ b/test/environments/Environments.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render,
   RenderResult,
+  screen,
   waitFor
 } from "@testing-library/react";
 import { mockTheme } from "../testutils";
@@ -17,7 +18,7 @@ jest.mock("../../src/features/namespaces/namespacesApiSlice", () => ({
         data: [
           {
             id: 1,
-            name: "default"
+            name: "filesystem"
           }
         ]
       }
@@ -42,7 +43,7 @@ jest.mock("../../src/features/environments/environmentsApiSlice", () => ({
         data: [
           {
             id: 1,
-            namespace: { id: 1, name: "default" },
+            namespace: { id: 1, name: "filesystem" },
             name: "python-flask-env-2",
             current_build_id: 1,
             current_build: 1,
@@ -71,7 +72,7 @@ describe("<Environment />", () => {
       )
     );
     await waitFor(() => {
-      expect(component.queryByText("default")).toBeInTheDocument();
+      expect(component.queryByText("filesystem")).toBeInTheDocument();
     });
   });
 
@@ -85,12 +86,14 @@ describe("<Environment />", () => {
     expect(mockOnUpdateRefreshEnvironments).toHaveBeenCalledWith(false);
   });
 
-  it("should use search input to filter the environment ", () => {
+  it("should use search input to filter the environment ", async () => {
     const searchInput = component.getByPlaceholderText(
       "Search for environment"
     );
     fireEvent.change(searchInput, { target: { value: "python-flask-env-2" } });
 
-    expect(component.queryByText("python-flask-env-2")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("python-flask-env-2")).not.toBeNull();
+    });
   });
 });

--- a/test/helpers/namespaces.test.tsx
+++ b/test/helpers/namespaces.test.tsx
@@ -4,7 +4,8 @@ import {
   checkMyPrimaryNamespace,
   groupEnvsByNamespace,
   getMyPrimaryNamespace,
-  getSharedNamespaces
+  getSharedNamespaces,
+  namespaceMapper
 } from "../../src/utils/helpers/namespaces";
 
 const NEW_NAMESPACE = {
@@ -57,13 +58,9 @@ describe("namespaces", () => {
 
   describe("groupEnvsByNamespace", () => {
     it("should group environments by namespace prop", () => {
-      const envsGroupedByNamespace = groupEnvsByNamespace(ENVIRONMENTS, {
-        id: 1,
-        name: "admin"
-      });
+      const envsGroupedByNamespace = groupEnvsByNamespace(ENVIRONMENTS);
 
-      expect(envsGroupedByNamespace["default"].environments).toHaveLength(2);
-      expect(envsGroupedByNamespace["admin"].environments).toHaveLength(0);
+      expect(envsGroupedByNamespace["default"]).toHaveLength(2);
     });
   });
 
@@ -76,8 +73,15 @@ describe("namespaces", () => {
 
   describe("getSharedNamespaces", () => {
     it("should return my shared namespaces", () => {
-      const myPrimaryNamespace = getSharedNamespaces(PARSED_NAMESPACES);
-      expect(myPrimaryNamespace).toEqual([PARSED_NAMESPACES[0]]);
+      const sharedNamespaces = getSharedNamespaces(PARSED_NAMESPACES);
+      expect(sharedNamespaces).toEqual([PARSED_NAMESPACES[0]]);
+    });
+  });
+
+  describe("namespaceMapper", () => {
+    it("should pap the namespace array to add the environments", () => {
+      const namespaces = namespaceMapper(ENVIRONMENTS, NAMESPACES);
+      expect(namespaces[0].environments).toHaveLength(2);
     });
   });
 });

--- a/test/helpers/namespaces.test.tsx
+++ b/test/helpers/namespaces.test.tsx
@@ -1,0 +1,83 @@
+import { NAMESPACES, ENVIRONMENTS } from "../testutils";
+import {
+  isNamespaceListed,
+  checkMyPrimaryNamespace,
+  groupEnvsByNamespace,
+  getMyPrimaryNamespace,
+  getSharedNamespaces
+} from "../../src/utils/helpers/namespaces";
+
+const NEW_NAMESPACE = {
+  id: 2,
+  name: "undefined-namespace"
+};
+
+const PARSED_NAMESPACES = [
+  {
+    namespace: "default",
+    environments: []
+  },
+  {
+    namespace: "admin",
+    environments: [],
+    isPrimary: true
+  }
+];
+
+describe("namespaces", () => {
+  describe("isNamespaceListed", () => {
+    it("should return true if the namespace is present", () => {
+      const isListed = isNamespaceListed(
+        [NEW_NAMESPACE, ...NAMESPACES],
+        NAMESPACES[0]
+      );
+      expect(isListed).toBeTruthy();
+    });
+
+    it("should return false if the namespace is not present", () => {
+      const isListed = isNamespaceListed(NAMESPACES, NEW_NAMESPACE);
+      expect(isListed).toBeFalsy();
+    });
+  });
+
+  describe("checkMyPrimaryNamespace", () => {
+    it("should return an array with a new prop called isPrimary as true if the primary namespace is listed", () => {
+      const namespaces = checkMyPrimaryNamespace(NAMESPACES, NAMESPACES[1]);
+      expect(namespaces[1]).toEqual({
+        ...namespaces[1],
+        isPrimary: true
+      });
+    });
+
+    it("should return an array without isPrimary prop", () => {
+      const namespaces = checkMyPrimaryNamespace(NAMESPACES, NEW_NAMESPACE);
+      expect(namespaces).toEqual(NAMESPACES);
+    });
+  });
+
+  describe("groupEnvsByNamespace", () => {
+    it("should group environments by namespace prop", () => {
+      const envsGroupedByNamespace = groupEnvsByNamespace(ENVIRONMENTS, {
+        id: 1,
+        name: "admin"
+      });
+
+      expect(envsGroupedByNamespace["default"].environments).toHaveLength(2);
+      expect(envsGroupedByNamespace["admin"].environments).toHaveLength(0);
+    });
+  });
+
+  describe("getMyPrimaryNamespace", () => {
+    it("should return my primary namespace", () => {
+      const myPrimaryNamespace = getMyPrimaryNamespace(PARSED_NAMESPACES);
+      expect(myPrimaryNamespace).toEqual(PARSED_NAMESPACES[1]);
+    });
+  });
+
+  describe("getSharedNamespaces", () => {
+    it("should return my shared namespaces", () => {
+      const myPrimaryNamespace = getSharedNamespaces(PARSED_NAMESPACES);
+      expect(myPrimaryNamespace).toEqual([PARSED_NAMESPACES[0]]);
+    });
+  });
+});

--- a/test/testutils.tsx
+++ b/test/testutils.tsx
@@ -3,6 +3,16 @@ import React from "react";
 import { CondaSpecification } from "../src/common/models";
 import { theme } from "../src/theme";
 
+export const NAMESPACES = [
+  {
+    id: 0,
+    name: "default"
+  },
+  {
+    id: 1,
+    name: "admin"
+  }
+];
 export const DEPENDENCIES = [
   {
     id: 3685,


### PR DESCRIPTION
- If the user is logged in, he should be able to see their primary namespace at the top. The default one is going to be listed in Shared Environments.
- If the user is not logged in, the primary namespace space is not visible, and the default namespace is still appearing in Shared environments.

**Updates and considerations:**
If the user does not have any environments, we are going to always display the default one (empty).
<img width="259" alt="Screen Shot 2022-12-28 at 1 43 11 PM" src="https://user-images.githubusercontent.com/5192743/209858358-95c62111-9c1a-4149-b6c1-bac189e69381.png">
If the user is logged in, we are going to display both namespaces: the primary and the default one.
<img width="259" alt="Screen Shot 2022-12-28 at 1 43 56 PM" src="https://user-images.githubusercontent.com/5192743/209858353-7ed0aa1f-34d5-40cd-8a61-5329ed799ece.png">
The user can interact with all the namespaces.
<img width="259" alt="Screen Shot 2022-12-28 at 8 33 03 AM" src="https://user-images.githubusercontent.com/5192743/209820144-874259b4-ad09-4561-9dd4-b9b11282900b.png">

