### PR TITLE
Fit the sidebar width according to their content

### DIFF
--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -28,7 +28,7 @@ export const PageLayout = () => {
     <Box
       sx={{
         display: "grid",
-        gridTemplateColumns: "260px 1fr",
+        gridTemplateColumns: "minmax(max-content, 275px) 1fr",
         width: "100%",
         height: "100%",
         background: "#FFF"


### PR DESCRIPTION
If the user has a long username, the sidebar was not fitting and, as a result, the name and the "+" were cut off.
With this approach, we don't need to care about the username's length because any content will affect the sidebar.

This feature was tested with different usernames:

<img width="392" alt="Screen Shot 2023-01-04 at 5 16 59 PM" src="https://user-images.githubusercontent.com/5192743/210660553-f26dc064-18af-476c-9064-b43d5b77ba99.png">
<img width="325" alt="Screen Shot 2023-01-04 at 5 16 44 PM" src="https://user-images.githubusercontent.com/5192743/210660578-837a8f6c-b967-4772-a76c-dd69496d3326.png">
<img width="275" alt="Screen Shot 2023-01-04 at 5 17 23 PM" src="https://user-images.githubusercontent.com/5192743/210660592-ccf5a1ed-7469-44bb-998c-95d9ebb6a7ec.png">
