### PR TITLE
Exclude packages with non-standard versions

### DIFF
--- a/src/components/VersionSelect.tsx
+++ b/src/components/VersionSelect.tsx
@@ -4,7 +4,7 @@ import MenuItem from "@mui/material/MenuItem";
 import useTheme from "@mui/material/styles/useTheme";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import IconButton from "@mui/material/IconButton";
-import { compareVersions, compare } from "compare-versions";
+import { compareVersions, compare, validate } from "compare-versions";
 import { useLazyGetPackageVersionSuggestionsQuery } from "../features/requestedPackages/requestedPackageVersionApiSlice";
 import {
   ActionTypes,
@@ -120,7 +120,9 @@ export const VersionSelect = ({
       }
     });
 
-    sortedVersions = result.sort(compareVersions);
+    // Remove non-standard versions (eg 0.5.0.pre) to avoid error on sort
+    const validVersions = result.filter(v => validate(v));
+    sortedVersions = validVersions.sort(compareVersions);
 
     sortedVersions.forEach(v => {
       if (v !== "" && value !== "") {

--- a/test/components/VersionSelect.test.tsx
+++ b/test/components/VersionSelect.test.tsx
@@ -17,6 +17,9 @@ jest.mock(
             },
             {
               version: "2.0"
+            },
+            {
+              version: "0.5.0.pre" // Real-world example: pyarrow 0.5.0.pre
             }
           ]
         }


### PR DESCRIPTION
compare-versions will throw an error if it encounters something like '0.5.0.pre'. A quick workaround is to just exclude them from the selection list.

this should fix #204 