### PR TITLE
Update environment build id by using the dropdown

### DIFF
--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -116,6 +116,7 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
         <EnvMetadata
           mode={mode}
           onUpdateDescription={handleChangeDescription}
+          onUpdateBuildId={() => {}}
         />
       </Box>
       <Box sx={{ marginBottom: "30px" }}>

--- a/src/features/environmentDetails/environmentDetailsApiSlice.ts
+++ b/src/features/environmentDetails/environmentDetailsApiSlice.ts
@@ -14,9 +14,21 @@ export const environmentDetailsApiSlice = apiSlice.injectEndpoints({
         method: "POST",
         body: code
       })
+    }),
+    updateBuildId: builder.mutation({
+      query: ({ namespace, environment, buildId }) => ({
+        url: `/api/v1/environment/${namespace}/${environment}/`,
+        method: "PUT",
+        body: {
+          build_id: buildId
+        }
+      })
     })
   })
 });
 
-export const { useGetBuildQuery, useCreateOrUpdateMutation } =
-  environmentDetailsApiSlice;
+export const {
+  useGetBuildQuery,
+  useCreateOrUpdateMutation,
+  useUpdateBuildIdMutation
+} = environmentDetailsApiSlice;

--- a/src/features/metadata/components/EnvBuilds.tsx
+++ b/src/features/metadata/components/EnvBuilds.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { CircularProgress, Typography } from "@mui/material";
 import { StyledMetadataItem } from "../../../styles/StyledMetadataItem";
+import { Build as IBuild } from "../../../common/models";
 import { Build } from "../../../features/metadata/components";
 import { buildMapper } from "../../../utils/helpers/buildMapper";
-import { useAppSelector } from "../../../hooks";
 
 interface IData {
   selectedBuildId: number;
+  builds: IBuild[];
 }
 
-export const EnvBuilds = ({ selectedBuildId }: IData) => {
-  const { builds } = useAppSelector(state => state.enviroments);
+export const EnvBuilds = ({ selectedBuildId, builds }: IData) => {
   const envBuilds = builds.length ? buildMapper(builds, selectedBuildId) : [];
   const currentBuild = envBuilds.find(build => build.id === selectedBuildId);
 

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useAppSelector } from "../../../hooks";
 import { BlockContainer } from "../../../components";
 import { Description, EnvBuilds } from "../../../features/metadata/components";
+import { StyledButtonPrimary } from "../../../styles";
 
 export enum EnvironmentDetailsModes {
   "CREATE" = "create",
@@ -17,6 +19,7 @@ interface IEnvMetadataProps {
   currentBuildId?: number | undefined;
   selectedBuildId?: number;
   onUpdateDescription: (description: string) => void;
+  onUpdateBuildId: (buildId: number) => void;
 }
 
 export const EnvMetadata = ({
@@ -24,8 +27,13 @@ export const EnvMetadata = ({
   description = "",
   currentBuildId,
   selectedBuildId,
-  onUpdateDescription
+  onUpdateDescription,
+  onUpdateBuildId
 }: IEnvMetadataProps) => {
+  const { builds, newCurrentBuild } = useAppSelector(
+    state => state.enviroments
+  );
+
   return (
     <BlockContainer title="Environment Metadata">
       <Description
@@ -33,9 +41,33 @@ export const EnvMetadata = ({
         description={description || undefined}
         onChangeDescription={onUpdateDescription}
       />
-      {mode !== EnvironmentDetailsModes.CREATE &&
-        currentBuildId &&
-        selectedBuildId && <EnvBuilds selectedBuildId={selectedBuildId} />}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "15px"
+        }}
+      >
+        {mode !== EnvironmentDetailsModes.CREATE &&
+          currentBuildId &&
+          selectedBuildId && (
+            <div>
+              <EnvBuilds selectedBuildId={selectedBuildId} builds={builds} />
+            </div>
+          )}
+
+        {mode === EnvironmentDetailsModes.EDIT &&
+          newCurrentBuild &&
+          currentBuildId !== newCurrentBuild && (
+            <StyledButtonPrimary
+              variant="contained"
+              onClick={() => onUpdateBuildId(newCurrentBuild)}
+              isalttype="true"
+            >
+              Update Environment Build
+            </StyledButtonPrimary>
+          )}
+      </div>
     </BlockContainer>
   );
 };

--- a/src/features/metadata/metadataSlice.ts
+++ b/src/features/metadata/metadataSlice.ts
@@ -9,6 +9,7 @@ export interface IBuildState {
   count: number;
   size: number;
   currentBuild: { id: number | undefined };
+  newCurrentBuild: number | undefined;
 }
 
 const initialState: IBuildState = {
@@ -17,7 +18,8 @@ const initialState: IBuildState = {
   page: 1,
   count: 0,
   size: 0,
-  currentBuild: { id: undefined }
+  currentBuild: { id: undefined },
+  newCurrentBuild: undefined
 };
 
 export const enviromentsSlice = createSlice({
@@ -28,7 +30,12 @@ export const enviromentsSlice = createSlice({
       state,
       action: PayloadAction<number | undefined>
     ) => {
-      state.currentBuild.id = action.payload;
+      const newBuildId = action.payload;
+      state.currentBuild.id = newBuildId;
+
+      const build = state.builds.find(build => build.id === newBuildId);
+      state.newCurrentBuild =
+        build && build.status === "COMPLETED" ? build.id : undefined;
     },
     updateBuilds: (state, action: PayloadAction<Build[]>) => {
       state.builds = action.payload;

--- a/src/features/tabs/tabsSlice.ts
+++ b/src/features/tabs/tabsSlice.ts
@@ -117,6 +117,11 @@ export const tabsSlice = createSlice({
         state.selectedEnvironment = null;
       }
       state.newEnvironment.isActive = action.payload;
+    },
+    updateEnvironmentBuildId: (state, action) => {
+      if (state.selectedEnvironment) {
+        state.selectedEnvironment.current_build_id = action.payload;
+      }
     }
   }
 });
@@ -127,5 +132,6 @@ export const {
   tabChanged,
   openCreateNewEnvironmentTab,
   closeCreateNewEnvironmentTab,
-  toggleNewEnvironmentView
+  toggleNewEnvironmentView,
+  updateEnvironmentBuildId
 } = tabsSlice.actions;

--- a/test/metadata/EnvBuilds.test.tsx
+++ b/test/metadata/EnvBuilds.test.tsx
@@ -1,33 +1,26 @@
 import React from "react";
 import { Provider } from "react-redux";
-import { act, render, RenderResult } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { EnvBuilds } from "../../src/features/metadata/components";
 import { BUILD } from "../testutils";
 import { store } from "../../src/store";
-import { updateBuilds } from "../../src/features/metadata";
 
 describe("<EnvBuilds />", () => {
-  let component: RenderResult;
-
-  beforeEach(() => {
-    component = render(
+  it("should render component", () => {
+    const component = render(
       <Provider store={store}>
-        <EnvBuilds currentBuildId={1} selectedBuildId={1} />
+        <EnvBuilds selectedBuildId={1} builds={[BUILD]} />
       </Provider>
     );
-  });
-
-  it("should render component", () => {
-    act(() => {
-      store.dispatch(updateBuilds([BUILD]));
-    });
     expect(component.container).toHaveTextContent("Builds");
   });
 
   it("should show a progress bar if builds are not available", () => {
-    act(() => {
-      store.dispatch(updateBuilds([]));
-    });
+    const component = render(
+      <Provider store={store}>
+        <EnvBuilds selectedBuildId={1} builds={[]} />
+      </Provider>
+    );
     const progressBar = component.getByRole("progressbar");
     expect(progressBar).toBeInTheDocument();
   });

--- a/test/metadata/EnvMetadata.test.tsx
+++ b/test/metadata/EnvMetadata.test.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { Provider } from "react-redux";
 import { fireEvent, render } from "@testing-library/react";
+import { store } from "../../src/store";
 import { EnvMetadata } from "../../src/features/metadata/components/EnvMetadata";
 import { mockTheme } from "../testutils";
 
@@ -7,12 +9,15 @@ describe("<EnvMetadata />", () => {
   it("should render component in read-only mode", () => {
     const component = render(
       mockTheme(
-        <EnvMetadata
-          mode="read-only"
-          description="test"
-          currentBuildId={0}
-          onUpdateDescription={() => ({})}
-        />
+        <Provider store={store}>
+          <EnvMetadata
+            mode="read-only"
+            description="test"
+            currentBuildId={0}
+            onUpdateDescription={() => ({})}
+            onUpdateBuildId={() => {}}
+          />
+        </Provider>
       )
     );
 
@@ -23,12 +28,15 @@ describe("<EnvMetadata />", () => {
     let description;
     const component = render(
       mockTheme(
-        <EnvMetadata
-          mode="edit"
-          description="test"
-          currentBuildId={0}
-          onUpdateDescription={e => (description = e)}
-        />
+        <Provider store={store}>
+          <EnvMetadata
+            mode="edit"
+            description="test"
+            currentBuildId={0}
+            onUpdateDescription={e => (description = e)}
+            onUpdateBuildId={() => {}}
+          />
+        </Provider>
       )
     );
     const newDescription = "Awesome new description";


### PR DESCRIPTION
- The feature is only available in edit mode.
- If the user tries to update the environment with a failed build, the button does not appear.
- If the build id selected is the same as the current one, the button does not appear.

The following record can be useful in order to understand the new update environment build id behavior:

https://user-images.githubusercontent.com/5192743/217143425-07ca150f-8e01-4bef-bfb3-07acea7ad3b7.mov

