### PR TITLE
validate when ended_on prop  is null

### DIFF
--- a/src/common/models/Build.ts
+++ b/src/common/models/Build.ts
@@ -17,6 +17,6 @@ export type Build = {
   size: number;
   scheduled_on: string;
   started_on: string;
-  ended_on: string;
+  ended_on: string | null;
   build_artifacts: BuildArtifact[];
 };

--- a/src/features/metadata/components/EnvBuilds.tsx
+++ b/src/features/metadata/components/EnvBuilds.tsx
@@ -6,12 +6,13 @@ import { buildMapper } from "../../../utils/helpers/buildMapper";
 import { useAppSelector } from "../../../hooks";
 
 interface IData {
+  currentBuildId: number;
   selectedBuildId: number;
 }
 
-export const EnvBuilds = ({ selectedBuildId }: IData) => {
+export const EnvBuilds = ({ currentBuildId, selectedBuildId }: IData) => {
   const { builds } = useAppSelector(state => state.enviroments);
-  const envBuilds = builds.length ? buildMapper(builds, selectedBuildId) : [];
+  const envBuilds = builds.length ? buildMapper(builds, currentBuildId) : [];
   const currentBuild = envBuilds.find(build => build.id === selectedBuildId);
 
   return (

--- a/src/features/metadata/components/EnvMetadata.tsx
+++ b/src/features/metadata/components/EnvMetadata.tsx
@@ -35,7 +35,12 @@ export const EnvMetadata = ({
       />
       {mode !== EnvironmentDetailsModes.CREATE &&
         currentBuildId &&
-        selectedBuildId && <EnvBuilds selectedBuildId={selectedBuildId} />}
+        selectedBuildId && (
+          <EnvBuilds
+            currentBuildId={currentBuildId}
+            selectedBuildId={selectedBuildId}
+          />
+        )}
     </BlockContainer>
   );
 };

--- a/src/utils/helpers/buildMapper.ts
+++ b/src/utils/helpers/buildMapper.ts
@@ -28,6 +28,9 @@ const isCompleted = (status: string) => {
 };
 
 const dateToTimezone = (date: string) => {
+  if (!date) {
+    return "";
+  }
   const zonedDate = utcToZonedTime(`${date}Z`, TIMEZONE);
   return format(zonedDate, "MMMM do, yyyy - h:mm a", {
     timeZone: TIMEZONE
@@ -36,14 +39,10 @@ const dateToTimezone = (date: string) => {
 
 export const buildMapper = (data: Build[], currentBuildId: number) => {
   return data.map(({ id, status, ended_on, scheduled_on }: Build) => {
-    const dateDetails =
-      isBuilding(status) || isQueued(status) ? scheduled_on : ended_on;
-    const date = dateToTimezone(dateDetails);
-
     if (id === currentBuildId) {
       return {
         id,
-        name: `${date} - Active`,
+        name: `${dateToTimezone(ended_on ?? scheduled_on)} - Active`,
         status: isCompleted(status)
       };
     }
@@ -51,7 +50,7 @@ export const buildMapper = (data: Build[], currentBuildId: number) => {
     if (isBuilding(status)) {
       return {
         id,
-        name: `${date} - Building`,
+        name: `${dateToTimezone(scheduled_on)} - Building`,
         status: "Building"
       };
     }
@@ -59,14 +58,16 @@ export const buildMapper = (data: Build[], currentBuildId: number) => {
     if (isQueued(status)) {
       return {
         id,
-        name: `${date} - Queued`,
+        name: `${dateToTimezone(scheduled_on)} - Queued`,
         status: "Building"
       };
     }
 
     return {
       id,
-      name: `${date} - ${STATUS_OPTIONS[status]}`,
+      name: `${dateToTimezone(ended_on ?? scheduled_on)} - ${
+        STATUS_OPTIONS[status]
+      }`,
       status: isCompleted(status)
     };
   });

--- a/test/helpers/BuildMapper.test.tsx
+++ b/test/helpers/BuildMapper.test.tsx
@@ -37,4 +37,18 @@ describe("buildMapper", () => {
     const [mappedBuild] = buildMapper(builds, 2);
     expect(mappedBuild.name).toContain("Failed");
   });
+
+  it("should use the scheduled_on date if the ended_on prop is null", () => {
+    const [mappedBuild] = buildMapper(
+      [
+        {
+          ...BUILD,
+          status: "FAILED",
+          ended_on: null
+        }
+      ],
+      2
+    );
+    expect(mappedBuild.name).toContain("November 8th, 2022 - 9:28 AM - Failed");
+  });
 });


### PR DESCRIPTION
### Improvements

- Before we transform the date to display in the dropdown, let's make sure the value for the ended_on prop isn't undefined. If it is undefined, use the scheduled_on prop.
- When you select a new build from the dropdown, the selected one becomes active; this should not happen. The current build ID should remain active until the user changes it. (Feature ready to be merged in #208)

https://user-images.githubusercontent.com/5192743/217296905-cf94126c-883c-4fbf-b2fc-230d6f0466c4.mov


