### PR TITLE
Create environments based on the namespaces' permissions.

### DIFF
--- a/src/common/interfaces/NamespaceEnvironments.ts
+++ b/src/common/interfaces/NamespaceEnvironments.ts
@@ -4,4 +4,6 @@ export interface INamespaceEnvironments {
   namespace: string;
   environments: Environment[];
   isPrimary?: boolean;
+  canCreate?: boolean;
+  canUpdate?: boolean;
 }

--- a/src/common/models/Environment.ts
+++ b/src/common/models/Environment.ts
@@ -5,4 +5,5 @@ export type Environment = {
   current_build_id: number;
   current_build: number | null;
   description: string;
+  canUpdate?: boolean;
 };

--- a/src/common/models/Namespace.ts
+++ b/src/common/models/Namespace.ts
@@ -2,4 +2,6 @@ export type Namespace = {
   id: number | undefined;
   name: string;
   isPrimary?: boolean;
+  canUpdate?: boolean;
+  canCreate?: boolean;
 };

--- a/src/features/environmentCreate/components/EnvironmentCreate.tsx
+++ b/src/features/environmentCreate/components/EnvironmentCreate.tsx
@@ -83,7 +83,8 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
       dispatch(
         environmentOpened({
           environment,
-          selectedEnvironmentId: newEnvId
+          selectedEnvironmentId: newEnvId,
+          canUpdate: true
         })
       );
       dispatch(currentBuildIdChanged(data.build_id));
@@ -101,7 +102,10 @@ export const EnvironmentCreate = ({ environmentNotification }: IEnvCreate) => {
 
   return (
     <Box sx={{ padding: "14px 12px" }}>
-      <EnvironmentDetailsHeader onUpdateName={handleChangeName} />
+      <EnvironmentDetailsHeader
+        onUpdateName={handleChangeName}
+        showEditButton={true}
+      />
       {error.visible && (
         <Alert
           severity="error"

--- a/src/features/environmentDetails/components/EnvironmentDetails.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetails.tsx
@@ -185,7 +185,11 @@ export const EnvironmentDetails = ({
 
   return (
     <Box sx={{ padding: "15px 12px" }}>
-      <EnvironmentDetailsHeader envName={name} onUpdateName={setName} />
+      <EnvironmentDetailsHeader
+        envName={name}
+        onUpdateName={setName}
+        showEditButton={selectedEnvironment?.canUpdate}
+      />
       {error.visible && (
         <Alert
           severity="error"

--- a/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
+++ b/src/features/environmentDetails/components/EnvironmentDetailsHeader.tsx
@@ -15,12 +15,14 @@ interface IEnvironmentDetailsHeaderProps {
    * @param onUpdateName change environment name
    */
   envName?: string;
+  showEditButton: boolean | undefined;
   onUpdateName: (value: string) => void;
 }
 
 export const EnvironmentDetailsHeader = ({
   envName = "",
-  onUpdateName
+  onUpdateName,
+  showEditButton = true
 }: IEnvironmentDetailsHeaderProps) => {
   const { mode } = useAppSelector(state => state.environmentDetails);
   const dispatch = useAppDispatch();
@@ -42,6 +44,8 @@ export const EnvironmentDetailsHeader = ({
           </Typography>
           {mode === EnvironmentDetailsModes.READ && (
             <StyledButtonPrimary
+              // TODO: Add this prop when the toggle button (YAML view) feature is added to the read-only view. #213
+              // disabled={!showEditButton}
               onClick={() =>
                 dispatch(modeChanged(EnvironmentDetailsModes.EDIT))
               }
@@ -54,6 +58,8 @@ export const EnvironmentDetailsHeader = ({
       {mode === EnvironmentDetailsModes.CREATE && (
         <>
           <TextField
+            autoFocus
+            placeholder="Environment name"
             sx={{
               backgroundColor: "#EBECEE",
               minWidth: "450px",
@@ -68,7 +74,6 @@ export const EnvironmentDetailsHeader = ({
                 color: "#333"
               }
             }}
-            placeholder="Environment name"
             onChange={e => onUpdateName(e.target.value)}
           />
           {/* <StyledButtonPrimary>Archive</StyledButtonPrimary> */}

--- a/src/features/environments/components/EnvironmentDropdown.tsx
+++ b/src/features/environments/components/EnvironmentDropdown.tsx
@@ -104,8 +104,8 @@ export const EnvironmentDropdown = ({
           <Tooltip
             title={
               canCreate
-                ? "Create a new environment"
-                : "You do not have permission to create an environment"
+                ? `Create a new environment in the ${namespace} namespace`
+                : `You do not have permission to create an environment in the ${namespace} namespace`
             }
           >
             <IconButton onClick={e => onCreateNewEnvironmentTab(e, namespace)}>

--- a/src/features/environments/components/EnvironmentDropdown.tsx
+++ b/src/features/environments/components/EnvironmentDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Accordion from "@mui/material/Accordion";
 import AddIcon from "@mui/icons-material/Add";
+import Tooltip from "@mui/material/Tooltip";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
@@ -35,7 +36,7 @@ interface IEnvironmentDropdownProps {
 }
 
 export const EnvironmentDropdown = ({
-  data: { namespace, environments }
+  data: { namespace, environments, canCreate, canUpdate }
 }: IEnvironmentDropdownProps) => {
   const { selectedEnvironment } = useAppSelector(state => state.tabs);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -50,6 +51,11 @@ export const EnvironmentDropdown = ({
     event: React.SyntheticEvent,
     namespace: string
   ) => {
+    if (!canCreate) {
+      event.stopPropagation();
+      return;
+    }
+
     if (isExpanded) {
       event.stopPropagation();
     }
@@ -95,9 +101,22 @@ export const EnvironmentDropdown = ({
           >
             {namespace}
           </Typography>
-          <IconButton onClick={e => onCreateNewEnvironmentTab(e, namespace)}>
-            <AddIcon sx={addIconStyles} />
-          </IconButton>
+          <Tooltip
+            title={
+              canCreate
+                ? "Create a new environment"
+                : "You do not have permission to create an environment"
+            }
+          >
+            <IconButton onClick={e => onCreateNewEnvironmentTab(e, namespace)}>
+              <AddIcon
+                sx={{
+                  ...addIconStyles,
+                  ...(!canCreate && { color: "#e5e5e5" })
+                }}
+              />
+            </IconButton>
+          </Tooltip>
         </Box>
       </StyledAccordionSummary>
       <AccordionDetails
@@ -115,7 +134,8 @@ export const EnvironmentDropdown = ({
                   dispatch(
                     environmentOpened({
                       environment,
-                      selectedEnvironmentId: selectedEnvironment?.id
+                      selectedEnvironmentId: selectedEnvironment?.id,
+                      canUpdate
                     })
                   );
                   dispatch(modeChanged(EnvironmentDetailsModes.READ));

--- a/src/features/tabs/tabsSlice.ts
+++ b/src/features/tabs/tabsSlice.ts
@@ -33,13 +33,17 @@ export const tabsSlice = createSlice({
       action: PayloadAction<{
         environment: Environment;
         selectedEnvironmentId: number | undefined;
+        canUpdate?: boolean;
       }>
     ) => {
       const environments = state.selectedEnvironments;
       const openedEnvironment = action.payload.environment;
       const isSingleTabMode = process.env.REACT_APP_CONTEXT === "jupyterlab";
 
-      state.selectedEnvironment = openedEnvironment;
+      state.selectedEnvironment = {
+        ...openedEnvironment,
+        canUpdate: action.payload.canUpdate
+      };
       state.value = openedEnvironment.id;
 
       if (!environments.some(env => env.id === openedEnvironment.id)) {

--- a/src/utils/helpers/namespaces.ts
+++ b/src/utils/helpers/namespaces.ts
@@ -3,9 +3,9 @@ import { Environment, Namespace } from "../../common/models";
 
 const DEFAULT = "default";
 const PERMISSIONS = {
-  update: "environment::update",
-  create: "namespace::create",
-  delete: "environment::delete"
+  environmentUpdate: "environment::update",
+  namespaceCreate: "namespace::create",
+  environmentDelete: "environment::delete"
 };
 
 /**
@@ -145,10 +145,10 @@ export const namespacesPermissionsMapper = (
       name: namespace.name,
       canCreate: allPermissions
         ? true
-        : namespacePermissions.includes(PERMISSIONS.create),
+        : namespacePermissions.includes(PERMISSIONS.namespaceCreate),
       canUpdate: allPermissions
         ? true
-        : namespacePermissions.includes(PERMISSIONS.update)
+        : namespacePermissions.includes(PERMISSIONS.environmentUpdate)
     };
   });
 };

--- a/src/utils/helpers/namespaces.ts
+++ b/src/utils/helpers/namespaces.ts
@@ -2,6 +2,11 @@ import { INamespaceEnvironments } from "../../common/interfaces";
 import { Environment, Namespace } from "../../common/models";
 
 const DEFAULT = "default";
+const PERMISSIONS = {
+  update: "environment::update",
+  create: "namespace::create",
+  delete: "environment::delete"
+};
 
 /**
  * Validate if my own namespace is already listed in the namespace array.
@@ -35,7 +40,9 @@ export const checkMyPrimaryNamespace = (
     if (item.name === primaryNamespace.name) {
       return {
         ...item,
-        isPrimary: primaryNamespace.name !== DEFAULT
+        isPrimary: primaryNamespace.name !== DEFAULT,
+        canUpdate: true,
+        canCreate: true
       };
     }
     return item;
@@ -74,7 +81,9 @@ export const namespaceMapper = (
     return {
       namespace: namespace.name,
       environments: environments[namespace.name] ?? [],
-      isPrimary: !!namespace.isPrimary
+      isPrimary: !!namespace.isPrimary,
+      canCreate: namespace.canCreate,
+      canUpdate: namespace.canUpdate
     };
   });
 };
@@ -119,4 +128,27 @@ export const getSharedNamespaces = (
       return undefined;
     }
   );
+};
+
+export const namespacesPermissionsMapper = (
+  namespaces: Namespace[],
+  permissions: any
+) => {
+  return namespaces.map((namespace: Namespace) => {
+    const entity = `${namespace.name}/*`;
+    const allPermissions = permissions.data.entity_permissions["*/*"];
+    const namespacePermissions =
+      permissions.data.entity_permissions[entity] ?? [];
+
+    return {
+      id: namespace.id,
+      name: namespace.name,
+      canCreate: allPermissions
+        ? true
+        : namespacePermissions.includes(PERMISSIONS.create),
+      canUpdate: allPermissions
+        ? true
+        : namespacePermissions.includes(PERMISSIONS.update)
+    };
+  });
 };

--- a/test/environmentDetails/EnvironmentDetailsHeader.test.tsx
+++ b/test/environmentDetails/EnvironmentDetailsHeader.test.tsx
@@ -17,6 +17,7 @@ describe("<EnvironmentDetailsHeader />", () => {
           <EnvironmentDetailsHeader
             envName="Environment name"
             onUpdateName={jest.fn()}
+            showEditButton={true}
           />
         </Provider>
       )
@@ -39,6 +40,7 @@ describe("<EnvironmentDetailsHeader />", () => {
           <EnvironmentDetailsHeader
             envName="Environment name"
             onUpdateName={jest.fn()}
+            showEditButton={true}
           />
         </Provider>
       )
@@ -59,6 +61,7 @@ describe("<EnvironmentDetailsHeader />", () => {
           <EnvironmentDetailsHeader
             envName={undefined}
             onUpdateName={mockOnUpdateName}
+            showEditButton={true}
           />
         </Provider>
       )

--- a/test/environments/EnvironmentDropdown.test.tsx
+++ b/test/environments/EnvironmentDropdown.test.tsx
@@ -1,39 +1,54 @@
 import React from "react";
 import { Provider } from "react-redux";
-import { fireEvent, render, RenderResult } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { ENVIRONMENT, mockTheme } from "../testutils";
 import { EnvironmentDropdown } from "../../src/features/environments";
 import { store } from "../../src/store";
 
+const mountEnvironmentDropdownComponent = (props: any) => {
+  return render(
+    mockTheme(
+      <Provider store={store}>
+        <EnvironmentDropdown
+          data={{
+            ...props,
+            namespace: "default",
+            environments: [ENVIRONMENT]
+          }}
+        />
+      </Provider>
+    )
+  );
+};
 describe("<EnvironmentDropdown />", () => {
-  let component: RenderResult;
-
-  beforeEach(() => {
-    component = render(
-      mockTheme(
-        <Provider store={store}>
-          <EnvironmentDropdown
-            data={{
-              namespace: "default",
-              environments: [ENVIRONMENT]
-            }}
-          />
-        </Provider>
-      )
-    );
-  });
-
-  it("should render with correct namespace", () => {
-    expect(component.container).toHaveTextContent("default");
+  it("should not open a new tab environment", () => {
+    const component = mountEnvironmentDropdownComponent({
+      canCreate: false,
+      canUpdate: false
+    });
+    const namespaceButton = component.getByTestId("AddIcon");
+    fireEvent.click(namespaceButton);
+    expect(store.getState().environmentDetails.mode).toBe("read-only");
   });
 
   it("should open a new tab environment", () => {
+    const component = mountEnvironmentDropdownComponent({
+      canCreate: true,
+      canUpdate: true
+    });
+
+    expect(component.container).toHaveTextContent("default");
+
     const namespaceButton = component.getByTestId("AddIcon");
     fireEvent.click(namespaceButton);
     expect(store.getState().environmentDetails.mode).toBe("create");
   });
 
   it("should open selected environment", () => {
+    const component = mountEnvironmentDropdownComponent({
+      canCreate: true,
+      canUpdate: true
+    });
     const environmentButton = component.getByText(ENVIRONMENT.name);
     fireEvent.click(environmentButton);
     expect(store.getState().tabs.selectedEnvironment?.name).toBe(

--- a/test/environments/Environments.test.tsx
+++ b/test/environments/Environments.test.tsx
@@ -27,11 +27,12 @@ jest.mock("../../src/features/namespaces/namespacesApiSlice", () => ({
   useLazyFetchPrimaryNamespaceQuery: jest.fn(() => [
     () => ({
       data: {
-        data: [
-          {
-            primary_namespace: "admin"
+        data: {
+          primary_namespace: "admin",
+          entity_permissions: {
+            "filesystem/*": ["environment::read", "namespace::create"]
           }
-        ]
+        }
       }
     })
   ])

--- a/test/helpers/namespaces.test.tsx
+++ b/test/helpers/namespaces.test.tsx
@@ -5,7 +5,8 @@ import {
   groupEnvsByNamespace,
   getMyPrimaryNamespace,
   getSharedNamespaces,
-  namespaceMapper
+  namespaceMapper,
+  namespacesPermissionsMapper
 } from "../../src/utils/helpers/namespaces";
 
 const NEW_NAMESPACE = {
@@ -16,12 +17,16 @@ const NEW_NAMESPACE = {
 const PARSED_NAMESPACES = [
   {
     namespace: "default",
-    environments: []
+    environments: [],
+    canCreate: true,
+    canUpdate: true
   },
   {
     namespace: "admin",
     environments: [],
-    isPrimary: true
+    isPrimary: true,
+    canCreate: true,
+    canUpdate: true
   }
 ];
 
@@ -79,9 +84,39 @@ describe("namespaces", () => {
   });
 
   describe("namespaceMapper", () => {
-    it("should pap the namespace array to add the environments", () => {
+    it("should map the namespace array to add the environments", () => {
       const namespaces = namespaceMapper(ENVIRONMENTS, NAMESPACES);
       expect(namespaces[0].environments).toHaveLength(2);
+    });
+  });
+
+  describe("namespacesPermissionsMapper", () => {
+    it("should return the namespaces with their permissions", () => {
+      const namespaces = [
+        {
+          id: 1,
+          name: "filesystem"
+        }
+      ];
+      const permissions = {
+        data: {
+          entity_permissions: {
+            "filesystem/*": [
+              "environment::read",
+              "namespace::create",
+              "environment::delete"
+            ]
+          }
+        }
+      };
+
+      const namespacesPermissions = namespacesPermissionsMapper(
+        namespaces,
+        permissions
+      );
+      expect(namespacesPermissions).toEqual([
+        { id: 1, name: "filesystem", canCreate: true, canUpdate: false }
+      ]);
     });
   });
 });


### PR DESCRIPTION
### Based on the `/permissions` endpoint, add the ability to create an environment inside a namespace
The endpoint above retrieves the following information: 

```
{
    status: "ok",
    data: {
        authenticated: true,
        primary_namespace: "admin",
        entity_permissions: {
            "default/*": ["environment::read", "namespace::read"],
            "filesystem/*": ["environment::read", "namespace::read"],
            "admin/*": [
                "build::delete",
                "environment::delete",
                "environment::read",
                "environment::update",
                "environment:create",
                "namespace::create",
                "namespace::delete",
                "namespace::read"
            ]
        },
        entity_roles: {
            "default/*": ["viewer"],
            "filesystem/*": ["viewer"],
            "admin/*": ["admin"]
        },
        expiration: "2023-02-14T15:19:36+00:00"
    },
    message: null
};
```
- We are [validating](https://github.com/Quansight/conda-store-ui/compare/main...jujogi:conda-store-ui:feature/readonly-namespaces?expand=1#diff-81e3f09cbe5d43074bb253e5c622de0cb34d37c1780700fc6e81431c009067cfR133) each namespace with the `entity_permissions` property and their permissions array. With that in mind, the namespace called `admin` has the ability to create, update, and delete namespaces/environments.
- [The ability to disable the edit button](https://github.com/Quansight/conda-store-ui/compare/main...jujogi:conda-store-ui:feature/readonly-namespaces?expand=1#diff-94ef25f59c2c8c3029b2096c0302eb1879d0285c47f4849cdc179941ea489373R48) from the read-only view if the user does not have permission `environment::update` was introduced. But for now, we commented that logic until the toggle button (YAML view) is added there as well.

https://user-images.githubusercontent.com/5192743/218518547-e12bca86-b4ca-4d47-aef1-8762da6e3621.mov



