### PR TITLE
Fix scrolling left sidebar issue

### DIFF
--- a/src/features/environments/components/EnvironmentsList.tsx
+++ b/src/features/environments/components/EnvironmentsList.tsx
@@ -57,13 +57,13 @@ export const EnvironmentsList = ({
 
   return (
     <StyledScrollContainer
-      sx={{ minHeight: "229px", maxHeight: "725px" }}
+      sx={{ height: "calc(100vh - 130px)" }}
       id="environmentsScroll"
       ref={scrollRef}
     >
       <InfiniteScroll
         scrollableTarget="environmentsScroll"
-        style={{ overflow: "hidden" }}
+        style={{ overflow: "hidden", paddingBottom: "25px" }}
         dataLength={environmentsList.length}
         hasMore={hasMore}
         next={next}

--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -1,12 +1,12 @@
 import { Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import React, { useState } from "react";
-
 import { Popup } from "../components";
 import { Environments } from "../features/environments";
 import { EnvironmentCreate } from "../features/environmentCreate";
 import { EnvironmentDetails } from "../features/environmentDetails";
 import { PageTabs } from "../features/tabs";
+import { StyledScrollContainer } from "../styles";
 import { useAppSelector } from "../hooks";
 
 export const PageLayout = () => {
@@ -38,11 +38,10 @@ export const PageLayout = () => {
         refreshEnvironments={isEnvCreated}
         onUpdateRefreshEnvironments={setIsEnvCreated}
       />
-      <Box
+      <StyledScrollContainer
         sx={{
-          width: "100%",
           backgroundColor: "#F9F9F9",
-          height: "100%",
+          height: "100vh",
           overflowY: "scroll"
         }}
       >
@@ -78,7 +77,7 @@ export const PageLayout = () => {
             </Typography>
           </Box>
         )}
-      </Box>
+      </StyledScrollContainer>
       <Popup
         isVisible={notification.show}
         description={notification.description}


### PR DESCRIPTION
According to this fix, the user should be able to expand all their namespaces and see the environment details without any problem, as the following video shows:

https://user-images.githubusercontent.com/5192743/218556154-babcf978-e59c-4b2a-b737-bb5a55da10f1.mov

