### PR TITLE
remove smooth scrolling when the user wants to add a package

### DIFF
--- a/src/features/channels/components/ChannelsEdit.tsx
+++ b/src/features/channels/components/ChannelsEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, memo } from "react";
+import React, { useState, useRef, memo } from "react";
 import { useTheme } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
@@ -35,7 +35,6 @@ const BaseChannelsEdit = ({
 }: IChannelsEditProps) => {
   const listLength = channelsList.length;
   const { palette } = useTheme();
-  const scrollRef = useRef<HTMLDivElement | null>(null);
   const expandedRef = useRef(listLength > 0);
 
   const [isAdding, setIsAdding] = useState(false);
@@ -70,12 +69,6 @@ const BaseChannelsEdit = ({
 
     updateChannels(reorderedArray);
   };
-
-  useEffect(() => {
-    if (isAdding && scrollRef.current) {
-      scrollRef.current.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [isAdding]);
 
   return (
     <Accordion
@@ -120,7 +113,7 @@ const BaseChannelsEdit = ({
                 </Draggable>
               ))}
               {provided.placeholder}
-              <Box ref={scrollRef}>
+              <Box>
                 {isAdding && (
                   <AddChannel
                     onSubmit={addNewChannel}

--- a/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
+++ b/src/features/environmentCreate/components/CreateEnvironmentPackages.tsx
@@ -1,3 +1,4 @@
+import React, { useState, useMemo } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -9,7 +10,6 @@ import {
 } from "@mui/material";
 import useTheme from "@mui/material/styles/useTheme";
 import { Box } from "@mui/system";
-import React, { useEffect, useRef, useState, useMemo } from "react";
 import { ArrowIcon } from "../../../components";
 import { useAppDispatch } from "../../../hooks";
 import {
@@ -35,19 +35,12 @@ export const CreateEnvironmentPackages = ({
 }: ICreateEnvironmentPackagesProps) => {
   const dispatch = useAppDispatch();
   const [isAdding, setIsAdding] = useState(false);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
   const { palette } = useTheme();
 
   const filteredRequestedPackages = useMemo(
     () => requestedPackages.filter(item => typeof item !== "object"),
     [requestedPackages]
   );
-
-  useEffect(() => {
-    if (isAdding && scrollRef.current) {
-      scrollRef.current.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [isAdding]);
 
   return (
     <Accordion
@@ -99,7 +92,7 @@ export const CreateEnvironmentPackages = ({
             ))}
           </TableBody>
         </Table>
-        <Box ref={scrollRef}>
+        <Box>
           {isAdding && (
             <AddRequestedPackage
               onSubmit={(value: string) =>

--- a/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
+++ b/src/features/requestedPackages/components/RequestedPackagesEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useState } from "react";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import Box from "@mui/material/Box";
@@ -35,7 +35,6 @@ export const RequestedPackagesEdit = ({
   const dispatch = useAppDispatch();
   const [isAdding, setIsAdding] = useState(false);
   const { palette } = useTheme();
-  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const handleSubmit = (packageName: string) => {
     dispatch(packageAdded(packageName));
@@ -45,12 +44,6 @@ export const RequestedPackagesEdit = ({
     () => packageList.filter(item => typeof item !== "object") as string[],
     [packageList]
   );
-
-  useEffect(() => {
-    if (isAdding && scrollRef.current) {
-      scrollRef.current.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [isAdding]);
 
   return (
     <Accordion
@@ -115,7 +108,7 @@ export const RequestedPackagesEdit = ({
             ))}
           </TableBody>
         </Table>
-        <Box ref={scrollRef}>
+        <Box>
           {isAdding && (
             <AddRequestedPackage
               onSubmit={handleSubmit}


### PR DESCRIPTION
This old approach to scrolling down when the user wants to add a package/channel was causing an issue inside Jupyter Lab.
Basically, instead of scrolling the component itself, we should scroll the parent element, which has the ability to do that.

https://user-images.githubusercontent.com/5192743/219144950-a7d5852b-0a57-4300-893f-b1911bb980ae.mov

