### PR TITLE
adds build and deploy to actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
-name: "Build"
+name: Build 
 on:
   pull_request:
+    branches: 
+      - '*'
   push:
-    branches:
+    branches: 
       - main
+
+  workflow_call:
 
 jobs:
   build:
@@ -19,11 +23,17 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+  
+      - name: Lint code
+        run: yarn eslint:check
 
-      - name: Build Image
+      - name: Build application
         run: yarn run build
 
-      - name: Test Install
-        run: yarn link 
+      - name: Build application artifacts
+        run: yarn run webpack bundle
       
-      
+      - uses: actions/upload-artifact@v3
+        with:
+          name: webpack-bundle
+          path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: "Build"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "Build Package"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build Image
+        run: yarn run build
+
+      - name: Test Install
+        run: yarn link 
+      
+      

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,16 +11,16 @@ jobs:
     uses: Quansight/conda-store-ui/.github/workflows/build.yml@main
 
   steps:
-  - name: Checkout
-    actions: actions/Checkout@v3
+    - name: Checkout
+      actions: actions/Checkout@v3
 
-  - name: Download build artifacts
-    uses: actions/download-artifact@v3
-    with:
-      name: webpack-bundle
-      path: dist/
+    - name: Download build artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: webpack-bundle
+        path: dist/
 
-  - name: Upload to npm
-    run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Upload to npm
+      run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  call-build:
+    uses: Quansight/conda-store-ui/.github/workflows/build.yml@main
+
+  steps:
+  - name: Checkout
+    actions: actions/Checkout@v3
+
+  - name: Download build artifacts
+    uses: actions/download-artifact@v3
+    with:
+      name: webpack-bundle
+      path: dist/
+
+  - name: Upload to npm
+    run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,17 +10,21 @@ jobs:
   call-build:
     uses: Quansight/conda-store-ui/.github/workflows/build.yml@main
 
-  steps:
-    - name: Checkout
-      actions: actions/Checkout@v3
+  deploy-build:
+    runs-on: ubuntu-latest
+    needs: call-build
 
-    - name: Download build artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: webpack-bundle
-        path: dist/
+    steps:
+      - name: Checkout
+        uses: actions/Checkout@v3
 
-    - name: Upload to npm
-      run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: webpack-bundle
+          path: dist/
+
+      - name: Upload to npm
+        run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adds actions to:

* Build on every push to main and every PR
* Uploading when a new release is cut and tagging said release on npm. For this purpose we should follow the nomenclature of 'v0.0.X-rcY' where X and Y are digits corresponding to the version and release candidate. The package will then be tagged the same, making it easier to install. 