### PR TITLE
Fix scrolling issue in JupyterLab extension

### DIFF
--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -29,6 +29,7 @@ export const PageLayout = () => {
       sx={{
         display: "grid",
         gridTemplateColumns: "minmax(max-content, 275px) 1fr",
+        gridTemplateRows: "100%",
         width: "100%",
         height: "100%",
         background: "#FFF"
@@ -41,7 +42,7 @@ export const PageLayout = () => {
       <StyledScrollContainer
         sx={{
           backgroundColor: "#F9F9F9",
-          height: "100vh",
+          height: "100%",
           overflowY: "scroll"
         }}
       >


### PR DESCRIPTION
It seems like using `vh` as the unit size to define a full height does not work as we expected inside the extension. 
The change is to define the two rows with 100% height.

### Before the fix:

https://user-images.githubusercontent.com/5192743/219706863-2c47b82f-38ed-42f0-9dd7-a6514a002d84.mov


### After the fix:

https://user-images.githubusercontent.com/5192743/219706970-02c8ecc2-ff50-4e9d-b027-71d99478d2fd.mov

