### PR TITLE
Keep conda-store-ui tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "clean": "rimraf conda-store*.tgz coverage dist lib storybook-static types .env  *.tsbuildinfo",
+    "clean": "rimraf coverage dist lib storybook-static types .env  *.tsbuildinfo",
     "clean:slate": "yarn run clean && rimraf node_modules",
     "eslint": "eslint . --ext .ts,.tsx --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
This PR removes the package.json line that removes the conda-store tarball, so we can actually upload it. 