### PR TITLE
remove removal of dist/ folder during yarn pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "clean": "rimraf coverage dist lib storybook-static types .env  *.tsbuildinfo",
+    "clean": "rimraf coverage lib storybook-static types .env  *.tsbuildinfo",
     "clean:slate": "yarn run clean && rimraf node_modules",
     "eslint": "eslint . --ext .ts,.tsx --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
Thie PR ensures that the dist folder is included in the package that is uplaoded to npm. 